### PR TITLE
typeOf cannot go wrong

### DIFF
--- a/ManifoldTests/InferenceTests.swift
+++ b/ManifoldTests/InferenceTests.swift
@@ -2,17 +2,17 @@
 
 final class InferenceTests: XCTestCase {
 	func testVariablesAreAssignedAFreshTypeVariable() {
-		assertEqual(assertRight(infer(0))?.0, Type(Variable()))
+		assertEqual(infer(0).0, Type(Variable()))
 	}
 
 	func testApplicationsAreAssignedAFreshTypeVariable() {
 		let application = 0 <| 0 // fixme: left operand should be an abstraction
-		assertEqual(assertRight(infer(application))?.0, Type(Variable()))
+		assertEqual(infer(application).0, Type(Variable()))
 	}
 
 	func testAbstractionsAreAssignedAFunctionType() {
 		let abstraction = 0 .. 0
-		assertEqual(assertRight(infer(abstraction))?.0, Type(Variable()) --> Type(Variable()))
+		assertEqual(infer(abstraction).0, Type(Variable()) --> Type(Variable()))
 	}
 }
 

--- a/ManifoldTests/InferenceTests.swift
+++ b/ManifoldTests/InferenceTests.swift
@@ -2,17 +2,17 @@
 
 final class InferenceTests: XCTestCase {
 	func testVariablesAreAssignedAFreshTypeVariable() {
-		assertEqual(assertRight(typeOf(0))?.0, Type(Variable()))
+		assertEqual(assertRight(infer(0))?.0, Type(Variable()))
 	}
 
 	func testApplicationsAreAssignedAFreshTypeVariable() {
 		let application = 0 <| 0 // fixme: left operand should be an abstraction
-		assertEqual(assertRight(typeOf(application))?.0, Type(Variable()))
+		assertEqual(assertRight(infer(application))?.0, Type(Variable()))
 	}
 
 	func testAbstractionsAreAssignedAFunctionType() {
 		let abstraction = 0 .. 0
-		assertEqual(assertRight(typeOf(abstraction))?.0, Type(Variable()) --> Type(Variable()))
+		assertEqual(assertRight(infer(abstraction))?.0, Type(Variable()) --> Type(Variable()))
 	}
 }
 


### PR DESCRIPTION
We don’t need to return Either, and we should probably not call it typeOf because that implies it’s done (it’s not).
