### PR TITLE
Sum types

### DIFF
--- a/Manifold/Constraint.swift
+++ b/Manifold/Constraint.swift
@@ -83,8 +83,12 @@ public func unify(t1: Type, t2: Type) -> Either<Error, Substitution> {
 	let constructed: Either<Error, Substitution>? = (t1.constructed &&& t2.constructed).map { c1, c2 -> Either<Error, Substitution> in
 		if c1.isUnit && c2.isUnit { return identity }
 		if c1.isBool && c2.isBool { return identity }
+		let recur: ((Type, Type), (Type, Type)) -> Either<Error, Substitution> = { (unify($0.0, $1.0) &&& unify($0.1, $1.1)).map(uncurry(Substitution.compose)) }
+		let function = (c1.function &&& c2.function).map(recur)
+		let sum = (c1.sum &&& c2.sum).map(recur)
 		return
-			(c1.function &&& c2.function).map { (unify($0.0, $1.0) &&& unify($0.1, $1.1)).map(uncurry(Substitution.compose)) }
+			function
+		??	sum
 		??	.left("mutually exclusive types: \(t1), \(t2)")
 	}
 

--- a/Manifold/Constraint.swift
+++ b/Manifold/Constraint.swift
@@ -66,10 +66,14 @@ public func === (left: Type, right: Type) -> Constraint {
 public typealias ConstraintSet = Multiset<Constraint>
 
 private func structural<T>(t1: Type, t2: Type, initial: T, f: (T, Type, Type) -> T) -> T {
+	let recur: ((Type, Type), (Type, Type)) -> T = {
+		structural($0.0, $1.0, structural($0.1, $1.1, f(initial, t1, t2), f), f)
+	}
+	let function = (t1.function &&& t2.function).map(recur)
+	let sum = (t1.sum &&& t2.sum).map(recur)
 	return
-		(t1.function &&& t2.function).map {
-			structural($0.0, $1.0, structural($0.1, $1.1, f(initial, t1, t2), f), f)
-		}
+		function
+	??	sum
 	??	f(initial, t1, t2)
 }
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -25,8 +25,8 @@ public enum Expression: Hashable, IntegerLiteralConvertible {
 
 		public var type: Type {
 			return analysis(
-				ifUnit: const(Type(.Unit)),
-				ifBool: const(Type(.Bool)))
+				ifUnit: const(Type.Unit),
+				ifBool: const(Type.Bool))
 		}
 
 

--- a/Manifold/Substitution.swift
+++ b/Manifold/Substitution.swift
@@ -31,7 +31,6 @@ public struct Substitution: DictionaryLiteralConvertible, Equatable, Printable {
 			ifConstructed: {
 				$0.analysis(
 					ifUnit: type,
-					ifBool: type,
 					ifFunction: { Type(function: self.apply($0), self.apply($1)) },
 					ifSum: { Type(sum: self.apply($0), self.apply($1)) })
 			},

--- a/Manifold/Substitution.swift
+++ b/Manifold/Substitution.swift
@@ -32,7 +32,8 @@ public struct Substitution: DictionaryLiteralConvertible, Equatable, Printable {
 				$0.analysis(
 					ifUnit: type,
 					ifBool: type,
-					ifFunction: { Type(function: self.apply($0), self.apply($1)) })
+					ifFunction: { Type(function: self.apply($0), self.apply($1)) },
+					ifSum: { Type(sum: self.apply($0), self.apply($1)) })
 			},
 			ifUniversal: { Type(forall: $0, self.apply($1)) })
 	}

--- a/Manifold/Type.swift
+++ b/Manifold/Type.swift
@@ -157,6 +157,13 @@ public enum Type: Hashable, Printable {
 			ifUniversal: { $1.function })
 	}
 
+	public var sum: (Type, Type)? {
+		return analysis(
+			ifVariable: const(nil),
+			ifConstructed: { $0.sum },
+			ifUniversal: { $1.sum })
+	}
+
 	public var universal: (Set<Manifold.Variable>, Type)? {
 		return analysis(
 			ifVariable: const(nil),

--- a/Manifold/Type.swift
+++ b/Manifold/Type.swift
@@ -64,6 +64,14 @@ public enum Type: Hashable, Printable {
 				ifSum: const(nil))
 		}
 
+		public var sum: (Type, Type)? {
+			return analysis(
+				ifUnit: nil,
+				ifBool: nil,
+				ifFunction: const(nil),
+				ifSum: unit)
+		}
+
 
 		// MARK: Recursive properties
 

--- a/ManifoldTests/TypeTests.swift
+++ b/ManifoldTests/TypeTests.swift
@@ -28,23 +28,23 @@ final class TypeTests: XCTestCase {
 	}
 
 	func testFunctionTypesPrintWithArrow() {
-		let t: Type = .Bool --> .Bool
-		assert(t.description, ==, "Bool → Bool")
+		let t: Type = .Unit --> .Unit
+		assert(t.description, ==, "Unit → Unit")
 	}
 
 	func testFunctionTypesParenthesizeParameterFunctions() {
-		let t: Type = (.Bool --> .Bool) --> .Bool
-		assert(t.description, ==, "(Bool → Bool) → Bool")
+		let t: Type = (.Unit --> .Unit) --> .Unit
+		assert(t.description, ==, "(Unit → Unit) → Unit")
 	}
 
 	func testFunctionTypesParenthesizeQuantifiedParameterFunctions() {
-		let t: Type = Type(forall: [ 0 ], Type(0) --> .Bool) --> .Bool
-		assert(t.description, ==, "(∀{α₀}.α₀ → Bool) → Bool")
+		let t: Type = Type(forall: [ 0 ], Type(0) --> .Unit) --> .Unit
+		assert(t.description, ==, "(∀{α₀}.α₀ → Unit) → Unit")
 	}
 
 	func testFunctionTypesDoNotParenthesizeReturnedFunctions() {
-		let t: Type = .Bool --> .Bool --> .Bool
-		assert(t.description, ==, "Bool → Bool → Bool")
+		let t: Type = .Unit --> .Unit --> .Unit
+		assert(t.description, ==, "Unit → Unit → Unit")
 	}
 
 	func testUniversalTypesPrintWithQuantifier() {


### PR DESCRIPTION
Add sum type constructors.
- [x] `Type.Constructor.Bool` should actually be a `Type.Constructor.Sum`.
- [x] Type inferencing should descend through sum types.
