### PR TITLE
Int literal variables update the cursor appropriately.

### DIFF
--- a/Manifold/Variable.swift
+++ b/Manifold/Variable.swift
@@ -21,6 +21,7 @@ public struct Variable: Comparable, Hashable, IntegerLiteralConvertible, Printab
 
 	public init(integerLiteral value: IntegerLiteralType) {
 		self.value = value
+		Variable.cursor = max(Variable.cursor, value + 1)
 	}
 
 


### PR DESCRIPTION
This fixes an issue where e.g. type scheme instantiation could use overlapping variables.
