### PR TITLE
Inference fixes

### DIFF
--- a/Manifold/Constraint.swift
+++ b/Manifold/Constraint.swift
@@ -104,7 +104,6 @@ public func unify(t1: Term, t2: Term) -> Either<Error, Substitution> {
 
 public func checkForInconsistencies(partition: [Term]) -> (Error?, Substitution) {
 	typealias Result = (Error?, Substitution, Term)
-	let initial: Result = (nil, [:], Term(Variable()))
 	let result: Result = reduce(dropFirst(partition), (nil, [:], first(partition)!)) { into, each in
 		unify(into.2, each).either(ifLeft: { error in (into.0.map { $0 + error } ?? error, into.1, each) }, ifRight: { (into.0, into.1.compose($0), each) })
 	}

--- a/Manifold/Constraint.swift
+++ b/Manifold/Constraint.swift
@@ -104,7 +104,7 @@ public func unify(t1: Term, t2: Term) -> Either<Error, Substitution> {
 
 public func checkForInconsistencies(partition: [Term]) -> (Error?, Substitution) {
 	typealias Result = (Error?, Substitution, Term)
-	let result: Result = reduce(dropFirst(partition), (nil, [:], first(partition)!)) { into, each in
+	let result: Result = reduce(dropFirst(partition), (nil, [:], partition[0])) { into, each in
 		unify(into.2, each).either(
 			ifLeft: { error in (into.0.map { $0 + error } ?? error, into.1, each) },
 			ifRight: { (into.0, into.1.compose($0), each) })

--- a/Manifold/Constraint.swift
+++ b/Manifold/Constraint.swift
@@ -102,8 +102,9 @@ public func unify(t1: Term, t2: Term) -> Either<Error, Substitution> {
 }
 
 
-public func checkForInconsistencies(partition: [Term]) -> (Error?, Substitution) {
+public func checkForInconsistencies(var partition: [Term]) -> (Error?, Substitution) {
 	typealias Result = (Error?, Substitution, Term)
+	sort(&partition) { $0.variable != nil || $1.variable == nil }
 	let result: Result = reduce(dropFirst(partition), (nil, [:], partition[0])) { into, each in
 		unify(into.2, each).either(
 			ifLeft: { error in (into.0.map { $0 + error } ?? error, into.1, each) },

--- a/Manifold/Constraint.swift
+++ b/Manifold/Constraint.swift
@@ -105,7 +105,9 @@ public func unify(t1: Term, t2: Term) -> Either<Error, Substitution> {
 public func checkForInconsistencies(partition: [Term]) -> (Error?, Substitution) {
 	typealias Result = (Error?, Substitution, Term)
 	let result: Result = reduce(dropFirst(partition), (nil, [:], first(partition)!)) { into, each in
-		unify(into.2, each).either(ifLeft: { error in (into.0.map { $0 + error } ?? error, into.1, each) }, ifRight: { (into.0, into.1.compose($0), each) })
+		unify(into.2, each).either(
+			ifLeft: { error in (into.0.map { $0 + error } ?? error, into.1, each) },
+			ifRight: { (into.0, into.1.compose($0), each) })
 	}
 	return (result.0, result.1)
 }


### PR DESCRIPTION
This is a bit of a hack to fix to an issue occurring in Tesseract, but it works: we sort variables ahead of type constructors so unifying will select them first.
