### PR TITLE
[BUG] Demonstrate a crasher reportedly on a default label

### DIFF
--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		D4B56CB31AFDA50B00D7BD6F /* Value.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B56CB21AFDA50B00D7BD6F /* Value.swift */; };
 		D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DE7E721AF66E25004D0CB9 /* Term.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
+		D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119B1B02FE8C002D9D9A /* Environment.swift */; };
 		D4F9F8651A84958000B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
 		D4F9F8661A84959600B7071E /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4B3FC141A83527B00DA2AC3 /* Box.framework */; };
 		D4F9F8671A84959600B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
@@ -55,6 +56,7 @@
 		D4B56CB21AFDA50B00D7BD6F /* Value.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		D4DE7E721AF66E25004D0CB9 /* Term.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Term.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
+		D4EE119B1B02FE8C002D9D9A /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		D4F9F8641A84958000B7071E /* Either.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86A1A8496F700B7071E /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86D1A84977400B7071E /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				D4B56CB01AFDA26A00D7BD6F /* Expression.swift */,
 				D4B56CB21AFDA50B00D7BD6F /* Value.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
+				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -263,6 +266,7 @@
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
+				D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */,
 				D4B56CB31AFDA50B00D7BD6F /* Value.swift in Sources */,
 				D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DE7E721AF66E25004D0CB9 /* Term.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119B1B02FE8C002D9D9A /* Environment.swift */; };
+		D4EE11A01B030048002D9D9A /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119F1B030048002D9D9A /* Natural.swift */; };
+		D4EE11A21B041D22002D9D9A /* NaturalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE11A11B041D22002D9D9A /* NaturalTests.swift */; };
 		D4F9F8651A84958000B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
 		D4F9F8661A84959600B7071E /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4B3FC141A83527B00DA2AC3 /* Box.framework */; };
 		D4F9F8671A84959600B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
@@ -57,6 +59,8 @@
 		D4DE7E721AF66E25004D0CB9 /* Term.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Term.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4EE119B1B02FE8C002D9D9A /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		D4EE119F1B030048002D9D9A /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
+		D4EE11A11B041D22002D9D9A /* NaturalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NaturalTests.swift; sourceTree = "<group>"; };
 		D4F9F8641A84958000B7071E /* Either.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86A1A8496F700B7071E /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86D1A84977400B7071E /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -118,6 +122,7 @@
 				D4B56CB21AFDA50B00D7BD6F /* Value.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
+				D4EE119F1B030048002D9D9A /* Natural.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -141,6 +146,7 @@
 			children = (
 				D4809FBC1AF6BD400084B8FE /* TermTests.swift */,
 				D46974241AFE4EB5005D3AA3 /* ValueTests.swift */,
+				D4EE11A11B041D22002D9D9A /* NaturalTests.swift */,
 				D4B3FC001A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = ManifoldTests;
@@ -263,6 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */,
+				D4EE11A01B030048002D9D9A /* Natural.swift in Sources */,
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
@@ -279,6 +286,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */,
+				D4EE11A21B041D22002D9D9A /* NaturalTests.swift in Sources */,
 				D46974251AFE4EB5005D3AA3 /* ValueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Manifold/Environment.swift
+++ b/Manifold/Environment.swift
@@ -1,0 +1,3 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public typealias Environment = [ Name: Value ]

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -14,6 +14,8 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 	switch (left, right) {
 	case (.Type, .Type):
 		return true
+	case let (.Constant(v1, t1), .Constant(v2, t2)):
+		return t1.value == t2.value
 	case let (.Bound(m), .Bound(n)):
 		return m == n
 	case let (.Free(m), .Free(n)):

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -34,6 +34,8 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 
 public func == (left: Name, right: Name) -> Bool {
 	switch (left, right) {
+	case let (.Global(x), .Global(y)):
+		return x == y
 	case let (.Local(x), .Local(y)):
 		return x == y
 	case let (.Quote(x), .Quote(y)):

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -5,6 +5,7 @@ public enum Expression<Recur> {
 
 	public func analysis<T>(
 		@noescape #ifType: () -> T,
+		@noescape ifConstant: (Any, Recur) -> T,
 		@noescape ifBound: Int -> T,
 		@noescape ifFree: Name -> T,
 		@noescape ifApplication: (Recur, Recur) -> T,
@@ -13,6 +14,8 @@ public enum Expression<Recur> {
 		switch self {
 		case .Type:
 			return ifType()
+		case let .Constant(value, type):
+			return ifConstant(value, type.value)
 		case let .Bound(x):
 			return ifBound(x)
 		case let .Free(x):
@@ -28,6 +31,7 @@ public enum Expression<Recur> {
 
 	public func analysis<T>(
 		ifType: (() -> T)? = nil,
+		ifConstant: ((Any, Recur) -> T)? = nil,
 		ifBound: (Int -> T)? = nil,
 		ifFree: (Name -> T)? = nil,
 		ifApplication: ((Recur, Recur) -> T)? = nil,
@@ -36,6 +40,7 @@ public enum Expression<Recur> {
 		@noescape otherwise: () -> T) -> T {
 		return analysis(
 			ifType: { ifType?() ?? otherwise() },
+			ifConstant: { ifConstant?($0) ?? otherwise() },
 			ifBound: { ifBound?($0) ?? otherwise() },
 			ifFree: { ifFree?($0) ?? otherwise() },
 			ifApplication: { ifApplication?($0) ?? otherwise() },
@@ -49,6 +54,7 @@ public enum Expression<Recur> {
 	public func map<T>(@noescape transform: Recur -> T) -> Expression<T> {
 		return analysis(
 			ifType: { .Type },
+			ifConstant: { .Constant($0, Box(transform($1))) },
 			ifBound: { .Bound($0) },
 			ifFree: { .Free($0) },
 			ifApplication: { .Application(Box(transform($0)), Box(transform($1))) },
@@ -60,6 +66,7 @@ public enum Expression<Recur> {
 	// MARK: Cases
 
 	case Type
+	case Constant(Any, Box<Recur>)
 	case Bound(Int)
 	case Free(Name)
 	case Application(Box<Recur>, Box<Recur>)

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -3,21 +3,24 @@
 public enum Name: Hashable, DebugPrintable, Printable {
 	// MARK: Destructors
 
-	public var value: Int {
-		return analysis(ifLocal: id, ifQuote: id)
+	public var global: String? {
+		return analysis(ifGlobal: unit, ifLocal: const(nil), ifQuote: const(nil))
 	}
 
-	public static func value(name: Name) -> Int {
-		return name.value
+	public var value: Int? {
+		return analysis(ifGlobal: const(nil), ifLocal: unit, ifQuote: unit)
 	}
 
 
 	// MARK: Analysis
 
 	public func analysis<T>(
-		@noescape #ifLocal: Int -> T,
+		@noescape #ifGlobal: String -> T,
+		@noescape ifLocal: Int -> T,
 		@noescape ifQuote: Int -> T) -> T {
 		switch self {
+		case let .Global(s):
+			return ifGlobal(s)
 		case let .Local(n):
 			return ifLocal(n)
 		case let .Quote(n):
@@ -30,6 +33,7 @@ public enum Name: Hashable, DebugPrintable, Printable {
 
 	public var debugDescription: String {
 		return analysis(
+			ifGlobal: { "Global(\($0))" },
 			ifLocal: { "Local(\($0))" },
 			ifQuote: { "Quote(\($0))" })
 	}
@@ -38,7 +42,7 @@ public enum Name: Hashable, DebugPrintable, Printable {
 	// MARK: Hashable
 
 	public var hashValue: Int {
-		return value
+		return analysis(ifGlobal: { $0.hashValue }, ifLocal: id, ifQuote: id)
 	}
 
 
@@ -51,6 +55,7 @@ public enum Name: Hashable, DebugPrintable, Printable {
 
 	// MARK: Cases
 
+	case Global(String)
 	case Local(Int)
 	case Quote(Int)
 }

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public enum Name: Hashable, DebugPrintable, Printable {
+public enum Name: Hashable, DebugPrintable, Printable, StringLiteralConvertible {
 	// MARK: Destructors
 
 	public var global: String? {
@@ -50,6 +50,21 @@ public enum Name: Hashable, DebugPrintable, Printable {
 
 	public var description: String {
 		return toString(value)
+	}
+
+
+	// MARK: StringLiteralConvertible
+
+	public init(stringLiteral value: String) {
+		self = Global(value)
+	}
+
+	public init(unicodeScalarLiteral value: String) {
+		self = Global(value)
+	}
+
+	public init(extendedGraphemeClusterLiteral value: String) {
+		self = Global(value)
 	}
 
 

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public enum Name: Hashable, DebugPrintable, Printable, StringLiteralConvertible {
+public enum Name: Hashable, IntegerLiteralConvertible, DebugPrintable, Printable, StringLiteralConvertible {
 	// MARK: Destructors
 
 	public var global: String? {
@@ -43,6 +43,13 @@ public enum Name: Hashable, DebugPrintable, Printable, StringLiteralConvertible 
 
 	public var hashValue: Int {
 		return analysis(ifGlobal: { $0.hashValue }, ifLocal: id, ifQuote: id)
+	}
+
+
+	// MARK: IntegerLiteralConvertible
+
+	public init(integerLiteral value: IntegerLiteralType) {
+		self = Local(value)
 	}
 
 

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -56,7 +56,10 @@ public enum Name: Hashable, IntegerLiteralConvertible, DebugPrintable, Printable
 	// MARK: Printable
 
 	public var description: String {
-		return toString(value)
+		return analysis(
+			ifGlobal: id,
+			ifLocal: toString,
+			ifQuote: toString)
 	}
 
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,0 +1,7 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public let naturalEnvironment: Environment = [
+	"Natural": .Type,
+	"Zero": Value.constant(0, .Free("Natural")),
+	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
+]

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -64,6 +64,8 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Type-checking
 
+	public typealias Environment = [ Int: Value ]
+
 	public var freeVariables: Set<Int> {
 		return expression.analysis(
 			ifBound: { [ $0.0 ] },
@@ -73,7 +75,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			otherwise: const([]))
 	}
 
-	public func typecheck(_ environment: [Int: Value] = [:]) -> Either<Error, Value> {
+	public func typecheck(_ environment: Environment = [:]) -> Either<Error, Value> {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),
 			ifBound: { i -> Either<Error, Value> in
@@ -102,7 +104,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			})
 	}
 
-	public func typecheck(environment: [Int: Value], _ against: Value) -> Either<Error, Value> {
+	public func typecheck(environment: Environment, _ against: Value) -> Either<Error, Value> {
 		return typecheck(environment)
 			.flatMap { t in
 				let (q, r) = (t.quote, against.quote)
@@ -115,7 +117,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Evaluation
 
-	public func evaluate(_ environment: [Int: Value] = [:]) -> Either<Error, Value> {
+	public func evaluate(_ environment: Environment = [:]) -> Either<Error, Value> {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),
 			ifBound: { i -> Either<Error, Value> in

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -93,7 +93,8 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 					?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
-				environment[i].map(Either.right)
+				environment[i]
+					.map { $0.quote.typecheck(environment) }
 					?? Either.left("unexpected free variable \(i)")
 			},
 			ifApplication: { a, b -> Either<Error, Value> in

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -203,7 +203,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		let alphabetize: Int -> String = { index in Swift.toString(Term.alphabet[advance(Term.alphabet.startIndex, index)]) }
 		return expression.analysis(
 			ifType: const("Type"),
-			ifConstant: { "(\($0)) : \($1)" },
+			ifConstant: { "(\($0)) : \($1.1)" },
 			ifBound: alphabetize,
 			ifFree: { $0.analysis(ifGlobal: id, ifLocal: alphabetize, ifQuote: alphabetize) },
 			ifApplication: { "(\($0.1)) (\($1.1))" },

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -191,7 +191,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		return expression.analysis(
 			ifType: const("Type"),
 			ifBound: alphabetize,
-			ifFree: Name.value >>> alphabetize,
+			ifFree: { $0.analysis(ifGlobal: id, ifLocal: alphabetize, ifQuote: alphabetize) },
 			ifApplication: { "(\($0.1)) (\($1.1))" },
 			ifPi: {
 				$2.0.freeVariables.contains($0)

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -64,8 +64,6 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Type-checking
 
-	public typealias Environment = [ Name: Value ]
-
 	public var freeVariables: Set<Int> {
 		return expression.analysis(
 			ifBound: { [ $0.0 ] },

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -90,7 +90,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifConstant: { $1.typecheck(environment) },
 			ifBound: { i -> Either<Error, Value> in
 				environment[.Local(i)].map(Either.right)
-					?? Either.left("unexpected free variable \(i)")
+					?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
 				environment[i].map(Either.right)
@@ -132,7 +132,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifType: const(Either.right(.Type)),
 			ifConstant: { $1.evaluate(environment).map(curry(Value.constant)($0)) },
 			ifBound: { i -> Either<Error, Value> in
-				environment[.Local(i)].map(Either.right) ?? Either.left("unexpected free variable \(i)")
+				environment[.Local(i)].map(Either.right) ?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
 				environment[i].map(Either.right) ?? Either.left("unexpected free variable \(i)")

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -40,6 +40,12 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			otherwise: const(false))
 	}
 
+	public var constant: (Any, Term)? {
+		return expression.analysis(
+			ifConstant: unit,
+			otherwise: const(nil))
+	}
+
 	public var bound: Int? {
 		return expression.analysis(
 			ifBound: unit,

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -27,6 +27,12 @@ public enum Value: DebugPrintable {
 			otherwise: const(false))
 	}
 
+	public var constant: (Any, Value)? {
+		return analysis(
+			ifConstant: unit,
+			otherwise: const(nil))
+	}
+
 	public var pi: (Value, Value -> Either<Error, Value>)? {
 		return analysis(
 			ifPi: unit,

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -33,6 +33,12 @@ public enum Value: DebugPrintable {
 			otherwise: const(nil))
 	}
 
+	public var free: Name? {
+		return analysis(
+			ifFree: unit,
+			otherwise: const(nil))
+	}
+
 	public var pi: (Value, Value -> Either<Error, Value>)? {
 		return analysis(
 			ifPi: unit,

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -57,6 +57,7 @@ public enum Value: DebugPrintable {
 			ifType: const(.type),
 			ifFree: {
 				$0.analysis(
+					ifGlobal: const(Term.free($0)),
 					ifLocal: const(Term.free($0)),
 					ifQuote: Term.bound)
 			},

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -1,0 +1,22 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class NaturalTests: XCTestCase {
+	func testReferencesToZeroAreWellTyped() {
+		assert(Zero.typecheck(naturalEnvironment).right?.quote, ==, Term(.Free("Natural")))
+//		(Zero.typecheck(naturalEnvironment).right?.quote).map(println)
+//		(Zero.evaluate(naturalEnvironment).right?.quote).map(println)
+	}
+
+	func testReferencesToZeroEvaluateToConstantValueOfZero() {
+		let result = Zero.evaluate(naturalEnvironment)
+		let constant = result.right?.constant
+		assert(constant?.0 as? Int, ==, 0)
+	}
+}
+
+let Zero = Term(.Free("Zero"))
+
+
+import Assertions
+import Manifold
+import XCTest

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -57,6 +57,15 @@ final class TermTests: XCTestCase {
 		assert(value.right?.quote, ==, identity)
 		assert(value.left, ==, nil)
 	}
+
+
+	func testGlobalsPrintTheirNames() {
+		assert(Term(.Free("Global")).description, ==, "Global")
+	}
+
+	func testConstantsPrintTheirValueAndType() {
+		assert(Term.constant(0, Term(.Free("Global"))).description, ==, "(0) : Global")
+	}
 }
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -32,7 +32,7 @@ final class TermTests: XCTestCase {
 
 
 	func testBoundVariablesEvaluateToTheValueBoundInTheEnvironment() {
-		assert(Term(.Bound(2)).evaluate([ 2: .Type ]).right?.quote, ==, Term.type)
+		assert(Term(.Bound(2)).evaluate([ .Local(2): .Type ]).right?.quote, ==, Term.type)
 	}
 
 	func testTrivialAbstractionEvaluatesToItself() {


### PR DESCRIPTION
This PR, in particular 23663d9b278125f95d8166bac1eb4a6d001559d7, demonstrates a couple of bugs:
1. I’m crashing in `==` in a way that basically shouldn’t be possible without a Swift bug (which I don’t know how to diagnose further).
2. The crash is being reported as being on the `default` line, which is ridiculous.

![image showing the reported line of the crash](https://pbs.twimg.com/media/CFBHl1iUIAER2LE.png:large)

Repro is to clone (recursively—need the submodules) & run the tests.

Occurring in Xcode Version 6.4 (6E14).
