### PR TITLE
Natural

### DIFF
--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119B1B02FE8C002D9D9A /* Environment.swift */; };
 		D4EE11A01B030048002D9D9A /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119F1B030048002D9D9A /* Natural.swift */; };
+		D4EE11A21B041D22002D9D9A /* NaturalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE11A11B041D22002D9D9A /* NaturalTests.swift */; };
 		D4F9F8651A84958000B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
 		D4F9F8661A84959600B7071E /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4B3FC141A83527B00DA2AC3 /* Box.framework */; };
 		D4F9F8671A84959600B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
@@ -59,6 +60,7 @@
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4EE119B1B02FE8C002D9D9A /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		D4EE119F1B030048002D9D9A /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
+		D4EE11A11B041D22002D9D9A /* NaturalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NaturalTests.swift; sourceTree = "<group>"; };
 		D4F9F8641A84958000B7071E /* Either.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86A1A8496F700B7071E /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86D1A84977400B7071E /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				D4809FBC1AF6BD400084B8FE /* TermTests.swift */,
 				D46974241AFE4EB5005D3AA3 /* ValueTests.swift */,
+				D4EE11A11B041D22002D9D9A /* NaturalTests.swift */,
 				D4B3FC001A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = ManifoldTests;
@@ -283,6 +286,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */,
+				D4EE11A21B041D22002D9D9A /* NaturalTests.swift in Sources */,
 				D46974251AFE4EB5005D3AA3 /* ValueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D45E2DC71B0AE55C004C64DA /* Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45E2DC61B0AE55C004C64DA /* Boolean.swift */; };
 		D46974251AFE4EB5005D3AA3 /* ValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46974241AFE4EB5005D3AA3 /* ValueTests.swift */; };
 		D46C90521B07B3A200975BFD /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46C90511B07B3A200975BFD /* Description.swift */; };
 		D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* TermTests.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D45E2DC61B0AE55C004C64DA /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
 		D46974241AFE4EB5005D3AA3 /* ValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
 		D46C90511B07B3A200975BFD /* Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Description.swift; sourceTree = "<group>"; };
 		D4809FBC1AF6BD400084B8FE /* TermTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermTests.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
 				D46C90511B07B3A200975BFD /* Description.swift */,
 				D4EE119F1B030048002D9D9A /* Natural.swift */,
+				D45E2DC61B0AE55C004C64DA /* Boolean.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -275,6 +278,7 @@
 				D4EE11A01B030048002D9D9A /* Natural.swift in Sources */,
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
+				D45E2DC71B0AE55C004C64DA /* Boolean.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
 				D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */,
 				D46C90521B07B3A200975BFD /* Description.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		D4B56CB31AFDA50B00D7BD6F /* Value.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B56CB21AFDA50B00D7BD6F /* Value.swift */; };
 		D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DE7E721AF66E25004D0CB9 /* Term.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
+		D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119B1B02FE8C002D9D9A /* Environment.swift */; };
 		D4F9F8651A84958000B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
 		D4F9F8661A84959600B7071E /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4B3FC141A83527B00DA2AC3 /* Box.framework */; };
 		D4F9F8671A84959600B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
@@ -55,6 +56,7 @@
 		D4B56CB21AFDA50B00D7BD6F /* Value.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Value.swift; sourceTree = "<group>"; };
 		D4DE7E721AF66E25004D0CB9 /* Term.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Term.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
+		D4EE119B1B02FE8C002D9D9A /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		D4F9F8641A84958000B7071E /* Either.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86A1A8496F700B7071E /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86D1A84977400B7071E /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				D4B56CB01AFDA26A00D7BD6F /* Expression.swift */,
 				D4B56CB21AFDA50B00D7BD6F /* Value.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
+				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -263,6 +266,7 @@
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
+				D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */,
 				D4B56CB31AFDA50B00D7BD6F /* Value.swift in Sources */,
 				D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D46974251AFE4EB5005D3AA3 /* ValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46974241AFE4EB5005D3AA3 /* ValueTests.swift */; };
+		D46C90521B07B3A200975BFD /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46C90511B07B3A200975BFD /* Description.swift */; };
 		D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* TermTests.swift */; };
 		D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBE1AF6CD720084B8FE /* Equatable.swift */; };
 		D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A31B291AA366EC00B3FC68 /* Algebra.swift */; };
@@ -43,6 +44,7 @@
 
 /* Begin PBXFileReference section */
 		D46974241AFE4EB5005D3AA3 /* ValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
+		D46C90511B07B3A200975BFD /* Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Description.swift; sourceTree = "<group>"; };
 		D4809FBC1AF6BD400084B8FE /* TermTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermTests.swift; sourceTree = "<group>"; };
 		D4809FBE1AF6CD720084B8FE /* Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Equatable.swift; sourceTree = "<group>"; };
 		D4A31B291AA366EC00B3FC68 /* Algebra.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Algebra.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				D4B56CB21AFDA50B00D7BD6F /* Value.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
+				D46C90511B07B3A200975BFD /* Description.swift */,
 				D4EE119F1B030048002D9D9A /* Natural.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
@@ -274,6 +277,7 @@
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
 				D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */,
+				D46C90521B07B3A200975BFD /* Description.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */,
 				D4B56CB31AFDA50B00D7BD6F /* Value.swift in Sources */,
 				D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		D45E2DC71B0AE55C004C64DA /* Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45E2DC61B0AE55C004C64DA /* Boolean.swift */; };
 		D46395AB1B143A7400AA1B65 /* Neutral.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46395AA1B143A7400AA1B65 /* Neutral.swift */; };
+		D46395AD1B15438600AA1B65 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46395AC1B15438600AA1B65 /* Context.swift */; };
 		D46974251AFE4EB5005D3AA3 /* ValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46974241AFE4EB5005D3AA3 /* ValueTests.swift */; };
 		D46C90521B07B3A200975BFD /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46C90511B07B3A200975BFD /* Description.swift */; };
 		D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* TermTests.swift */; };
@@ -47,6 +48,7 @@
 /* Begin PBXFileReference section */
 		D45E2DC61B0AE55C004C64DA /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
 		D46395AA1B143A7400AA1B65 /* Neutral.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Neutral.swift; sourceTree = "<group>"; };
+		D46395AC1B15438600AA1B65 /* Context.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
 		D46974241AFE4EB5005D3AA3 /* ValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
 		D46C90511B07B3A200975BFD /* Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Description.swift; sourceTree = "<group>"; };
 		D4809FBC1AF6BD400084B8FE /* TermTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermTests.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 				D46395AA1B143A7400AA1B65 /* Neutral.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
+				D46395AC1B15438600AA1B65 /* Context.swift */,
 				D46C90511B07B3A200975BFD /* Description.swift */,
 				D4EE119F1B030048002D9D9A /* Natural.swift */,
 				D45E2DC61B0AE55C004C64DA /* Boolean.swift */,
@@ -280,6 +283,7 @@
 				D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */,
 				D4EE11A01B030048002D9D9A /* Natural.swift in Sources */,
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
+				D46395AD1B15438600AA1B65 /* Context.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D45E2DC71B0AE55C004C64DA /* Boolean.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D45E2DC71B0AE55C004C64DA /* Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45E2DC61B0AE55C004C64DA /* Boolean.swift */; };
+		D46395AB1B143A7400AA1B65 /* Neutral.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46395AA1B143A7400AA1B65 /* Neutral.swift */; };
 		D46974251AFE4EB5005D3AA3 /* ValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46974241AFE4EB5005D3AA3 /* ValueTests.swift */; };
 		D46C90521B07B3A200975BFD /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46C90511B07B3A200975BFD /* Description.swift */; };
 		D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* TermTests.swift */; };
@@ -45,6 +46,7 @@
 
 /* Begin PBXFileReference section */
 		D45E2DC61B0AE55C004C64DA /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
+		D46395AA1B143A7400AA1B65 /* Neutral.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Neutral.swift; sourceTree = "<group>"; };
 		D46974241AFE4EB5005D3AA3 /* ValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueTests.swift; sourceTree = "<group>"; };
 		D46C90511B07B3A200975BFD /* Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Description.swift; sourceTree = "<group>"; };
 		D4809FBC1AF6BD400084B8FE /* TermTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermTests.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 				D4DE7E721AF66E25004D0CB9 /* Term.swift */,
 				D4B56CB01AFDA26A00D7BD6F /* Expression.swift */,
 				D4B56CB21AFDA50B00D7BD6F /* Value.swift */,
+				D46395AA1B143A7400AA1B65 /* Neutral.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
 				D46C90511B07B3A200975BFD /* Description.swift */,
@@ -281,6 +284,7 @@
 				D45E2DC71B0AE55C004C64DA /* Boolean.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
 				D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */,
+				D46395AB1B143A7400AA1B65 /* Neutral.swift in Sources */,
 				D46C90521B07B3A200975BFD /* Description.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */,
 				D4B56CB31AFDA50B00D7BD6F /* Value.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DE7E721AF66E25004D0CB9 /* Term.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4EE119C1B02FE8C002D9D9A /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119B1B02FE8C002D9D9A /* Environment.swift */; };
+		D4EE11A01B030048002D9D9A /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EE119F1B030048002D9D9A /* Natural.swift */; };
 		D4F9F8651A84958000B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
 		D4F9F8661A84959600B7071E /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4B3FC141A83527B00DA2AC3 /* Box.framework */; };
 		D4F9F8671A84959600B7071E /* Either.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4F9F8641A84958000B7071E /* Either.framework */; };
@@ -57,6 +58,7 @@
 		D4DE7E721AF66E25004D0CB9 /* Term.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Term.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4EE119B1B02FE8C002D9D9A /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		D4EE119F1B030048002D9D9A /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
 		D4F9F8641A84958000B7071E /* Either.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Either.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86A1A8496F700B7071E /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Prelude.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4F9F86D1A84977400B7071E /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				D4B56CB21AFDA50B00D7BD6F /* Value.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4EE119B1B02FE8C002D9D9A /* Environment.swift */,
+				D4EE119F1B030048002D9D9A /* Natural.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -263,6 +266,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */,
+				D4EE11A01B030048002D9D9A /* Natural.swift in Sources */,
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,

--- a/Manifold/Algebra.swift
+++ b/Manifold/Algebra.swift
@@ -8,27 +8,27 @@ public protocol FixpointType {
 }
 
 
-// MARK: Fix: FixpointType over Expression<Fix>
+// MARK: Fix: FixpointType over Checkable<Fix>
 
-public func cata<T, Fix: FixpointType where Fix.Recur == Expression<Fix>>(f: Expression<T> -> T)(_ term: Fix) -> T {
-	return term |> (out >>> (flip(uncurry(Expression.map)) <| cata(f)) >>> f)
+public func cata<T, Fix: FixpointType where Fix.Recur == Checkable<Fix>>(f: Checkable<T> -> T)(_ term: Fix) -> T {
+	return term |> (out >>> (flip(uncurry(Checkable.map)) <| cata(f)) >>> f)
 }
 
 
-public func para<T, Fix: FixpointType where Fix.Recur == Expression<Fix>>(f: Expression<(Fix, T)> -> T)(_ term: Fix) -> T {
+public func para<T, Fix: FixpointType where Fix.Recur == Checkable<Fix>>(f: Checkable<(Fix, T)> -> T)(_ term: Fix) -> T {
 	let fanout = { ($0, para(f)($0)) }
-	return term |> (out >>> (flip(uncurry(Expression.map)) <| fanout) >>> f)
+	return term |> (out >>> (flip(uncurry(Checkable.map)) <| fanout) >>> f)
 }
 
 
-public func ana<T, Fix: FixpointType where Fix.Recur == Expression<Fix>>(f: T -> Expression<T>)(_ seed: T) -> Fix {
-	return seed |> (`in` <<< (flip(uncurry(Expression.map)) <| ana(f)) <<< f)
+public func ana<T, Fix: FixpointType where Fix.Recur == Checkable<Fix>>(f: T -> Checkable<T>)(_ seed: T) -> Fix {
+	return seed |> (`in` <<< (flip(uncurry(Checkable.map)) <| ana(f)) <<< f)
 }
 
 
-public func apo<T, Fix: FixpointType where Fix.Recur == Expression<Fix>>(f: T -> Expression<Either<Fix, T>>)(_ seed: T) -> Fix {
+public func apo<T, Fix: FixpointType where Fix.Recur == Checkable<Fix>>(f: T -> Checkable<Either<Fix, T>>)(_ seed: T) -> Fix {
 	let fanin = flip(uncurry(Either<Fix, T>.either)) <| (id, { apo(f)($0) })
-	return seed |> (`in` <<< (flip(uncurry(Expression.map)) <| fanin) <<< f)
+	return seed |> (`in` <<< (flip(uncurry(Checkable.map)) <| fanin) <<< f)
 }
 
 

--- a/Manifold/Boolean.swift
+++ b/Manifold/Boolean.swift
@@ -3,6 +3,8 @@
 /// An environment containing Church-encoded booleans.
 public let booleanEnvironment: Environment = [
 	"Boolean": Value.pi(.Type) { bool in Value.pi(bool, const(Value.pi(bool, const(bool)))) },
+	"True": Value.pi(.Free("Boolean")) { t in Value.pi(.Free("Boolean"), const(t)) },
+	"False": Value.pi(.Free("Boolean")) { _ in Value.pi(.Free("Boolean")) { f in f } },
 ]
 
 

--- a/Manifold/Boolean.swift
+++ b/Manifold/Boolean.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// An environment containing Church-encoded booleans.
-public let booleanEnvironment: Environment = [
+public let booleanEnvironment: [Name: Value] = [
 	"Boolean": Value.pi(.Type) { bool in Value.pi(bool, const(Value.pi(bool, const(bool)))) },
 	"True": Value.pi(.parameter("Boolean")) { t in Value.pi(.parameter("Boolean"), const(t)) },
 	"False": Value.pi(.parameter("Boolean")) { _ in Value.pi(.parameter("Boolean")) { f in f } },

--- a/Manifold/Boolean.swift
+++ b/Manifold/Boolean.swift
@@ -1,11 +1,11 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// An environment containing Church-encoded booleans.
-public let booleanEnvironment: [Name: Value] = [
+public let booleanEnvironment: Environment = Environment([], [
 	"Boolean": Value.pi(.Type) { bool in Value.pi(bool, const(Value.pi(bool, const(bool)))) },
 	"True": Value.pi(.free("Boolean")) { t in Value.pi(.free("Boolean"), const(t)) },
 	"False": Value.pi(.free("Boolean")) { _ in Value.pi(.free("Boolean")) { f in f } },
-]
+])
 
 
 import Prelude

--- a/Manifold/Boolean.swift
+++ b/Manifold/Boolean.swift
@@ -3,8 +3,8 @@
 /// An environment containing Church-encoded booleans.
 public let booleanEnvironment: Environment = [
 	"Boolean": Value.pi(.Type) { bool in Value.pi(bool, const(Value.pi(bool, const(bool)))) },
-	"True": Value.pi(.Free("Boolean")) { t in Value.pi(.Free("Boolean"), const(t)) },
-	"False": Value.pi(.Free("Boolean")) { _ in Value.pi(.Free("Boolean")) { f in f } },
+	"True": Value.pi(.parameter("Boolean")) { t in Value.pi(.parameter("Boolean"), const(t)) },
+	"False": Value.pi(.parameter("Boolean")) { _ in Value.pi(.parameter("Boolean")) { f in f } },
 ]
 
 

--- a/Manifold/Boolean.swift
+++ b/Manifold/Boolean.swift
@@ -3,8 +3,8 @@
 /// An environment containing Church-encoded booleans.
 public let booleanEnvironment: [Name: Value] = [
 	"Boolean": Value.pi(.Type) { bool in Value.pi(bool, const(Value.pi(bool, const(bool)))) },
-	"True": Value.pi(.parameter("Boolean")) { t in Value.pi(.parameter("Boolean"), const(t)) },
-	"False": Value.pi(.parameter("Boolean")) { _ in Value.pi(.parameter("Boolean")) { f in f } },
+	"True": Value.pi(.free("Boolean")) { t in Value.pi(.free("Boolean"), const(t)) },
+	"False": Value.pi(.free("Boolean")) { _ in Value.pi(.free("Boolean")) { f in f } },
 ]
 
 

--- a/Manifold/Boolean.swift
+++ b/Manifold/Boolean.swift
@@ -1,0 +1,9 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+/// An environment containing Church-encoded booleans.
+public let booleanEnvironment: Environment = [
+	"Boolean": Value.pi(.Type) { bool in Value.pi(bool, const(Value.pi(bool, const(bool)))) },
+]
+
+
+import Prelude

--- a/Manifold/Context.swift
+++ b/Manifold/Context.swift
@@ -4,6 +4,10 @@ public typealias Type = Value
 
 public typealias Context = [(Name, Type)]
 
+public func lookup<A: Hashable, B>(dictionary: [A: B], key: A) -> B? {
+	return dictionary[key]
+}
+
 public func lookup<A: Equatable, B, S: SequenceType where S.Generator.Element == (A, B)>(sequence: S, key: A) -> B? {
 	for (k, v) in sequence {
 		if k == key { return v }

--- a/Manifold/Context.swift
+++ b/Manifold/Context.swift
@@ -3,3 +3,10 @@
 public typealias Type = Value
 
 public typealias Context = [(Name, Type)]
+
+public func lookup<A: Equatable, B, S: SequenceType where S.Generator.Element == (A, B)>(sequence: S, key: A) -> B? {
+	for (k, v) in sequence {
+		if k == key { return v }
+	}
+	return nil
+}

--- a/Manifold/Context.swift
+++ b/Manifold/Context.swift
@@ -2,7 +2,7 @@
 
 public typealias Type = Value
 
-public typealias Context = [(Name, Type)]
+public typealias Context = [Name: Type]
 
 public func lookup<A: Hashable, B>(dictionary: [A: B], key: A) -> B? {
 	return dictionary[key]

--- a/Manifold/Context.swift
+++ b/Manifold/Context.swift
@@ -7,10 +7,3 @@ public typealias Context = [Name: Type]
 public func lookup<A: Hashable, B>(dictionary: [A: B], key: A) -> B? {
 	return dictionary[key]
 }
-
-public func lookup<A: Equatable, B, S: SequenceType where S.Generator.Element == (A, B)>(sequence: S, key: A) -> B? {
-	for (k, v) in sequence {
-		if k == key { return v }
-	}
-	return nil
-}

--- a/Manifold/Context.swift
+++ b/Manifold/Context.swift
@@ -1,0 +1,5 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public typealias Type = Value
+
+public typealias Context = [(Name, Type)]

--- a/Manifold/Context.swift
+++ b/Manifold/Context.swift
@@ -3,7 +3,3 @@
 public typealias Type = Value
 
 public typealias Context = [Name: Type]
-
-public func lookup<A: Hashable, B>(dictionary: [A: B], key: A) -> B? {
-	return dictionary[key]
-}

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -19,7 +19,7 @@ public enum Description<Index> {
 
 	// MARK: Analyses
 
-	public func analysis<T>(@noescape ifEnd: Index -> T) -> T {
+	public func analysis<T>(@noescape #ifEnd: Index -> T) -> T {
 		switch self {
 		case let .End(index):
 			return ifEnd(index.value)

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -5,6 +5,17 @@ public enum Description<Index> {
 		return .End(Box(index))
 	}
 
+
+	var end: Index? {
+		switch self {
+		case let .End(index):
+			return index.value
+		default:
+			return nil
+		}
+	}
+
+
 	case End(Box<Index>)
 }
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -1,0 +1,5 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public enum Description<Index> {
+
+}

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -11,17 +11,23 @@ public enum Description<Index> {
 	// MARK: Destructors
 
 	var end: Index? {
-		return analysis(ifEnd: unit)
+		return analysis(
+			ifEnd: unit,
+			ifRecursive: const(nil))
 	}
 
 
 
 	// MARK: Analyses
 
-	public func analysis<T>(@noescape #ifEnd: Index -> T) -> T {
+	public func analysis<T>(
+		@noescape #ifEnd: Index -> T,
+		@noescape ifRecursive: (Index, Description) -> T) -> T {
 		switch self {
 		case let .End(index):
 			return ifEnd(index.value)
+		case let .Recursive(index, description):
+			return ifRecursive(index.value, description.value)
 		}
 	}
 
@@ -29,6 +35,7 @@ public enum Description<Index> {
 	// MARK: Cases
 
 	case End(Box<Index>)
+	case Recursive(Box<Index>, Box<Description>)
 }
 
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -1,6 +1,9 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public enum Description<Index> {
+	public static func end(index: Index) -> Description {
+		return .End(Box(index))
+	}
 
 	case End(Box<Index>)
 }

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -20,6 +20,11 @@ public enum Description<Index> {
 			ifRecursive: const(nil))
 	}
 
+	var recursive: (Index, Description)? {
+		return analysis(
+			ifEnd: const(nil),
+			ifRecursive: unit)
+	}
 
 
 	// MARK: Analyses
@@ -44,3 +49,4 @@ public enum Description<Index> {
 
 
 import Box
+import Prelude

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -1,10 +1,14 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public enum Description<Index> {
+	// MARK: Constructors
+
 	public static func end(index: Index) -> Description {
 		return .End(Box(index))
 	}
 
+
+	// MARK: Destructors
 
 	var end: Index? {
 		return analysis(ifEnd: unit)

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -18,21 +18,21 @@ public enum Description<Index> {
 
 	// MARK: Destructors
 
-	var end: Index? {
+	public var end: Index? {
 		return analysis(
 			ifEnd: unit,
 			ifRecursive: const(nil),
 			ifArgument: const(nil))
 	}
 
-	var recursive: (Index, Description)? {
+	public var recursive: (Index, Description)? {
 		return analysis(
 			ifEnd: const(nil),
 			ifRecursive: unit,
 			ifArgument: const(nil))
 	}
 
-	var argument: (Index, Any -> Description)? {
+	public var argument: (Index, Any -> Description)? {
 		return analysis(
 			ifEnd: const(nil),
 			ifRecursive: const(nil),

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -7,6 +7,10 @@ public enum Description<Index> {
 		return .End(Box(index))
 	}
 
+	public static func recursive(index: Index, _ description: Description) -> Description {
+		return .Recursive(Box(index), Box(description))
+	}
+
 
 	// MARK: Destructors
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -2,4 +2,8 @@
 
 public enum Description<Index> {
 
+	case End(Box<Index>)
 }
+
+
+import Box

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -7,12 +7,7 @@ public enum Description<Index> {
 
 
 	var end: Index? {
-		switch self {
-		case let .End(index):
-			return index.value
-		default:
-			return nil
-		}
+		return analysis(ifEnd: unit)
 	}
 
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -11,6 +11,10 @@ public enum Description<Index> {
 		return .Recursive(Box(index), Box(description))
 	}
 
+	public static func argument(index: Index, _ argument: Any -> Description) -> Description {
+		return .Argument(Box(index), argument)
+	}
+
 
 	// MARK: Destructors
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -19,7 +19,7 @@ public enum Description<Index> {
 
 	// MARK: Analyses
 
-	public func analysis<T>(ifEnd: Index -> T) -> T {
+	public func analysis<T>(@noescape ifEnd: Index -> T) -> T {
 		switch self {
 		case let .End(index):
 			return ifEnd(index.value)

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -32,6 +32,13 @@ public enum Description<Index> {
 			ifArgument: const(nil))
 	}
 
+	var argument: (Index, Any -> Description)? {
+		return analysis(
+			ifEnd: const(nil),
+			ifRecursive: const(nil),
+			ifArgument: unit)
+	}
+
 
 	// MARK: Analyses
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -17,13 +17,15 @@ public enum Description<Index> {
 	var end: Index? {
 		return analysis(
 			ifEnd: unit,
-			ifRecursive: const(nil))
+			ifRecursive: const(nil),
+			ifArgument: const(nil))
 	}
 
 	var recursive: (Index, Description)? {
 		return analysis(
 			ifEnd: const(nil),
-			ifRecursive: unit)
+			ifRecursive: unit,
+			ifArgument: const(nil))
 	}
 
 
@@ -31,12 +33,15 @@ public enum Description<Index> {
 
 	public func analysis<T>(
 		@noescape #ifEnd: Index -> T,
-		@noescape ifRecursive: (Index, Description) -> T) -> T {
+		@noescape ifRecursive: (Index, Description) -> T,
+		@noescape ifArgument: (Index, Any -> Description) -> T) -> T {
 		switch self {
 		case let .End(index):
 			return ifEnd(index.value)
 		case let .Recursive(index, description):
 			return ifRecursive(index.value, description.value)
+		case let .Argument(index, argument):
+			return ifArgument(index.value, argument)
 		}
 	}
 
@@ -45,6 +50,7 @@ public enum Description<Index> {
 
 	case End(Box<Index>)
 	case Recursive(Box<Index>, Box<Description>)
+	case Argument(Box<Index>, Any -> Description)
 }
 
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -16,6 +16,19 @@ public enum Description<Index> {
 	}
 
 
+
+	// MARK: Analyses
+
+	public func analysis<T>(ifEnd: Index -> T) -> T {
+		switch self {
+		case let .End(index):
+			return ifEnd(index.value)
+		}
+	}
+
+
+	// MARK: Cases
+
 	case End(Box<Index>)
 }
 

--- a/Manifold/Environment.swift
+++ b/Manifold/Environment.swift
@@ -1,3 +1,3 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public typealias Environment = [ Name: Value ]
+public typealias Environment = [Value]

--- a/Manifold/Environment.swift
+++ b/Manifold/Environment.swift
@@ -1,3 +1,20 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public typealias Environment = [Value]
+public struct Environment {
+	public init(_ local: [Value] = [], _ global: [Name: Value] = [:]) {
+		self.local = local
+		self.global = global
+	}
+
+	public let local: [Value]
+	public let global: [Name: Value]
+
+
+	public func byPrepending(value: Value) -> Environment {
+		return Environment([ value ] + local, global)
+	}
+}
+
+public func + (left: Environment, right: Environment) -> Environment {
+	return Environment(left.local + right.local, left.global + right.global)
+}

--- a/Manifold/Environment.swift
+++ b/Manifold/Environment.swift
@@ -1,0 +1,3 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public typealias Environment = [ Name: Value ]

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -14,6 +14,8 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 	switch (left, right) {
 	case (.Type, .Type):
 		return true
+	case let (.Constant(v1, t1), .Constant(v2, t2)):
+		return t1.value == t2.value
 	case let (.Bound(m), .Bound(n)):
 		return m == n
 	case let (.Free(m), .Free(n)):

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -1,16 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-// MARK: Error
+// MARK: Checkable
 
-public func == (left: Error, right: Error) -> Bool {
-	return reduce(lazy(zip(left.errors, right.errors))
-		.map(==), true) { $0 && $1 }
-}
-
-
-// MARK: Expression
-
-public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Recur>) -> Bool {
+public func == <Recur: Equatable> (left: Checkable<Recur>, right: Checkable<Recur>) -> Bool {
 	switch (left, right) {
 	case (.Type, .Type):
 		return true
@@ -34,6 +26,14 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 	default:
 		return false
 	}
+}
+
+
+// MARK: Error
+
+public func == (left: Error, right: Error) -> Bool {
+	return reduce(lazy(zip(left.errors, right.errors))
+		.map(==), true) { $0 && $1 }
 }
 
 

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -18,8 +18,15 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 		return t1.value == t2.value
 	case let (.Bound(m), .Bound(n)):
 		return m == n
-	case let (.Free(m), .Free(n)):
-		return m == n
+	case let (.Free(m), _):
+		// Workaround for rdar://20969594
+		switch right {
+		case let .Free(n):
+			return m == n
+		default:
+			break
+		}
+		return false
 	case let (.Application(t1, t2), .Application(u1, u2)):
 		return t1.value == u1.value && t2.value == u2.value
 	case let (.Pi(i, t, a), .Pi(j, u, b)):

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -34,6 +34,8 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 
 public func == (left: Name, right: Name) -> Bool {
 	switch (left, right) {
+	case let (.Global(x), .Global(y)):
+		return x == y
 	case let (.Local(x), .Local(y)):
 		return x == y
 	case let (.Quote(x), .Quote(y)):

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -19,10 +19,10 @@ public func == <Recur: Equatable> (left: Checkable<Recur>, right: Checkable<Recu
 		return false
 	case let (.Application(t1, t2), .Application(u1, u2)):
 		return t1.value == u1.value && t2.value == u2.value
-	case let (.Pi(i, t, a), .Pi(j, u, b)):
-		return i == j && t.value == u.value && a.value == b.value
-	case let (.Sigma(i, t, a), .Sigma(j, u, b)):
-		return i == j && t.value == u.value && a.value == b.value
+	case let (.Pi(t, a), .Pi(u, b)):
+		return t.value == u.value && a.value == b.value
+	case let (.Sigma(t, a), .Sigma(u, b)):
+		return t.value == u.value && a.value == b.value
 	default:
 		return false
 	}

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -14,8 +14,6 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 	switch (left, right) {
 	case (.Type, .Type):
 		return true
-	case let (.Constant(v1, t1), .Constant(v2, t2)):
-		return t1.value == t2.value
 	case let (.Bound(m), .Bound(n)):
 		return m == n
 	case let (.Free(m), _):

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -5,6 +5,7 @@ public enum Expression<Recur> {
 
 	public func analysis<T>(
 		@noescape #ifType: () -> T,
+		@noescape ifConstant: (Any, Recur) -> T,
 		@noescape ifBound: Int -> T,
 		@noescape ifFree: Name -> T,
 		@noescape ifApplication: (Recur, Recur) -> T,
@@ -13,6 +14,8 @@ public enum Expression<Recur> {
 		switch self {
 		case .Type:
 			return ifType()
+		case let .Constant(value, type):
+			return ifConstant(value, type.value)
 		case let .Bound(x):
 			return ifBound(x)
 		case let .Free(x):
@@ -28,6 +31,7 @@ public enum Expression<Recur> {
 
 	public func analysis<T>(
 		ifType: (() -> T)? = nil,
+		ifConstant: ((Any, Recur) -> T)? = nil,
 		ifBound: (Int -> T)? = nil,
 		ifFree: (Name -> T)? = nil,
 		ifApplication: ((Recur, Recur) -> T)? = nil,
@@ -36,6 +40,7 @@ public enum Expression<Recur> {
 		@noescape otherwise: () -> T) -> T {
 		return analysis(
 			ifType: { ifType?() ?? otherwise() },
+			ifConstant: { ifConstant?($0) ?? otherwise() },
 			ifBound: { ifBound?($0) ?? otherwise() },
 			ifFree: { ifFree?($0) ?? otherwise() },
 			ifApplication: { ifApplication?($0) ?? otherwise() },
@@ -49,6 +54,7 @@ public enum Expression<Recur> {
 	public func map<T>(@noescape transform: Recur -> T) -> Expression<T> {
 		return analysis(
 			ifType: { .Type },
+			ifConstant: { .Constant($0, Box(transform($1))) },
 			ifBound: { .Bound($0) },
 			ifFree: { .Free($0) },
 			ifApplication: { .Application(Box(transform($0)), Box(transform($1))) },
@@ -60,6 +66,7 @@ public enum Expression<Recur> {
 	// MARK: Cases
 
 	case Type
+	case Constant(Any, Box<Recur>)
 	case Bound(Int)
 	case Free(Name)
 	case Application(Box<Recur>, Box<Recur>)

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -5,7 +5,6 @@ public enum Expression<Recur> {
 
 	public func analysis<T>(
 		@noescape #ifType: () -> T,
-		@noescape ifConstant: (Any, Recur) -> T,
 		@noescape ifBound: Int -> T,
 		@noescape ifFree: Name -> T,
 		@noescape ifApplication: (Recur, Recur) -> T,
@@ -14,8 +13,6 @@ public enum Expression<Recur> {
 		switch self {
 		case .Type:
 			return ifType()
-		case let .Constant(value, type):
-			return ifConstant(value, type.value)
 		case let .Bound(x):
 			return ifBound(x)
 		case let .Free(x):
@@ -31,7 +28,6 @@ public enum Expression<Recur> {
 
 	public func analysis<T>(
 		ifType: (() -> T)? = nil,
-		ifConstant: ((Any, Recur) -> T)? = nil,
 		ifBound: (Int -> T)? = nil,
 		ifFree: (Name -> T)? = nil,
 		ifApplication: ((Recur, Recur) -> T)? = nil,
@@ -40,7 +36,6 @@ public enum Expression<Recur> {
 		@noescape otherwise: () -> T) -> T {
 		return analysis(
 			ifType: { ifType?() ?? otherwise() },
-			ifConstant: { ifConstant?($0) ?? otherwise() },
 			ifBound: { ifBound?($0) ?? otherwise() },
 			ifFree: { ifFree?($0) ?? otherwise() },
 			ifApplication: { ifApplication?($0) ?? otherwise() },
@@ -54,7 +49,6 @@ public enum Expression<Recur> {
 	public func map<T>(@noescape transform: Recur -> T) -> Expression<T> {
 		return analysis(
 			ifType: { .Type },
-			ifConstant: { .Constant($0, Box(transform($1))) },
 			ifBound: { .Bound($0) },
 			ifFree: { .Free($0) },
 			ifApplication: { .Application(Box(transform($0)), Box(transform($1))) },
@@ -66,7 +60,6 @@ public enum Expression<Recur> {
 	// MARK: Cases
 
 	case Type
-	case Constant(Any, Box<Recur>)
 	case Bound(Int)
 	case Free(Name)
 	case Application(Box<Recur>, Box<Recur>)

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public enum Expression<Recur> {
+public enum Checkable<Recur> {
 	// MARK: Analyses
 
 	public func analysis<T>(
@@ -46,7 +46,7 @@ public enum Expression<Recur> {
 
 	// MARK: Functor
 
-	public func map<T>(@noescape transform: Recur -> T) -> Expression<T> {
+	public func map<T>(@noescape transform: Recur -> T) -> Checkable<T> {
 		return analysis(
 			ifType: { .Type },
 			ifBound: { .Bound($0) },

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -8,8 +8,8 @@ public enum Checkable<Recur> {
 		@noescape ifBound: Int -> T,
 		@noescape ifFree: Name -> T,
 		@noescape ifApplication: (Recur, Recur) -> T,
-		@noescape ifPi: (Int, Recur, Recur) -> T,
-		@noescape ifSigma: (Int, Recur, Recur) -> T) -> T {
+		@noescape ifPi: (Recur, Recur) -> T,
+		@noescape ifSigma: (Recur, Recur) -> T) -> T {
 		switch self {
 		case .Type:
 			return ifType()
@@ -19,10 +19,10 @@ public enum Checkable<Recur> {
 			return ifFree(x)
 		case let .Application(a, b):
 			return ifApplication(a.value, b.value)
-		case let .Pi(i, a, b):
-			return ifPi(i, a.value, b.value)
-		case let .Sigma(i, a, b):
-			return ifSigma(i, a.value, b.value)
+		case let .Pi(a, b):
+			return ifPi(a.value, b.value)
+		case let .Sigma(a, b):
+			return ifSigma(a.value, b.value)
 		}
 	}
 
@@ -31,8 +31,8 @@ public enum Checkable<Recur> {
 		ifBound: (Int -> T)? = nil,
 		ifFree: (Name -> T)? = nil,
 		ifApplication: ((Recur, Recur) -> T)? = nil,
-		ifPi: ((Int, Recur, Recur) -> T)? = nil,
-		ifSigma: ((Int, Recur, Recur) -> T)? = nil,
+		ifPi: ((Recur, Recur) -> T)? = nil,
+		ifSigma: ((Recur, Recur) -> T)? = nil,
 		@noescape otherwise: () -> T) -> T {
 		return analysis(
 			ifType: { ifType?() ?? otherwise() },
@@ -52,8 +52,8 @@ public enum Checkable<Recur> {
 			ifBound: { .Bound($0) },
 			ifFree: { .Free($0) },
 			ifApplication: { .Application(Box(transform($0)), Box(transform($1))) },
-			ifPi: { .Pi($0, Box(transform($1)), Box(transform($2))) },
-			ifSigma: { .Sigma($0, Box(transform($1)), Box(transform($2))) })
+			ifPi: { .Pi(Box(transform($0)), Box(transform($1))) },
+			ifSigma: { .Sigma(Box(transform($0)), Box(transform($1))) })
 	}
 
 
@@ -63,8 +63,8 @@ public enum Checkable<Recur> {
 	case Bound(Int)
 	case Free(Name)
 	case Application(Box<Recur>, Box<Recur>)
-	case Pi(Int, Box<Recur>, Box<Recur>) // (Πx:A)B where B can depend on x
-	case Sigma(Int, Box<Recur>, Box<Recur>) // (Σx:A)B where B can depend on x
+	case Pi(Box<Recur>, Box<Recur>) // (Πx:A)B where B can depend on x
+	case Sigma(Box<Recur>, Box<Recur>) // (Σx:A)B where B can depend on x
 }
 
 

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -3,21 +3,24 @@
 public enum Name: Hashable, DebugPrintable, Printable {
 	// MARK: Destructors
 
-	public var value: Int {
-		return analysis(ifLocal: id, ifQuote: id)
+	public var global: String? {
+		return analysis(ifGlobal: unit, ifLocal: const(nil), ifQuote: const(nil))
 	}
 
-	public static func value(name: Name) -> Int {
-		return name.value
+	public var value: Int? {
+		return analysis(ifGlobal: const(nil), ifLocal: unit, ifQuote: unit)
 	}
 
 
 	// MARK: Analysis
 
 	public func analysis<T>(
-		@noescape #ifLocal: Int -> T,
+		@noescape #ifGlobal: String -> T,
+		@noescape ifLocal: Int -> T,
 		@noescape ifQuote: Int -> T) -> T {
 		switch self {
+		case let .Global(s):
+			return ifGlobal(s)
 		case let .Local(n):
 			return ifLocal(n)
 		case let .Quote(n):
@@ -30,6 +33,7 @@ public enum Name: Hashable, DebugPrintable, Printable {
 
 	public var debugDescription: String {
 		return analysis(
+			ifGlobal: { "Global(\($0))" },
 			ifLocal: { "Local(\($0))" },
 			ifQuote: { "Quote(\($0))" })
 	}
@@ -38,7 +42,7 @@ public enum Name: Hashable, DebugPrintable, Printable {
 	// MARK: Hashable
 
 	public var hashValue: Int {
-		return value
+		return analysis(ifGlobal: { $0.hashValue }, ifLocal: id, ifQuote: id)
 	}
 
 
@@ -51,6 +55,7 @@ public enum Name: Hashable, DebugPrintable, Printable {
 
 	// MARK: Cases
 
+	case Global(String)
 	case Local(Int)
 	case Quote(Int)
 }

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public enum Name: Hashable, DebugPrintable, Printable {
+public enum Name: Hashable, DebugPrintable, Printable, StringLiteralConvertible {
 	// MARK: Destructors
 
 	public var global: String? {
@@ -50,6 +50,21 @@ public enum Name: Hashable, DebugPrintable, Printable {
 
 	public var description: String {
 		return toString(value)
+	}
+
+
+	// MARK: StringLiteralConvertible
+
+	public init(stringLiteral value: String) {
+		self = Global(value)
+	}
+
+	public init(unicodeScalarLiteral value: String) {
+		self = Global(value)
+	}
+
+	public init(extendedGraphemeClusterLiteral value: String) {
+		self = Global(value)
 	}
 
 

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public enum Name: Hashable, DebugPrintable, Printable, StringLiteralConvertible {
+public enum Name: Hashable, IntegerLiteralConvertible, DebugPrintable, Printable, StringLiteralConvertible {
 	// MARK: Destructors
 
 	public var global: String? {
@@ -43,6 +43,13 @@ public enum Name: Hashable, DebugPrintable, Printable, StringLiteralConvertible 
 
 	public var hashValue: Int {
 		return analysis(ifGlobal: { $0.hashValue }, ifLocal: id, ifQuote: id)
+	}
+
+
+	// MARK: IntegerLiteralConvertible
+
+	public init(integerLiteral value: IntegerLiteralType) {
+		self = Local(value)
 	}
 
 

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -56,7 +56,10 @@ public enum Name: Hashable, IntegerLiteralConvertible, DebugPrintable, Printable
 	// MARK: Printable
 
 	public var description: String {
-		return toString(value)
+		return analysis(
+			ifGlobal: id,
+			ifLocal: toString,
+			ifQuote: toString)
 	}
 
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -4,7 +4,7 @@ public let naturalEnvironment: Environment = [
 	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
 	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
 	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in Value.application(f.neutral!, x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)
-	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
+	"Successor": Value.forall { N in Value.forall { X in Value.pi(N) { n in Value.pi(.function(X, X)) { f in Value.pi(X) { x in .application(f.neutral!, .application(.application(n.neutral!, f), x)) } } } } }, // ∀ N . ∀ F . ∀ X . λ n : N . λ f : F . λ x : X . f ((n f) x)
 ]
 
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -2,6 +2,9 @@
 
 public let naturalEnvironment: Environment = [
 	"Natural": .Type,
-	"Zero": Value.constant(0, .Free("Natural")),
+	"Zero": Value.forall { F in Value.forall { X in Value.pi(F, const(Value.pi(X, id))) } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . x
 	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
 ]
+
+
+import Prelude

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -4,7 +4,7 @@ public let naturalEnvironment: Environment = Environment([], [
 	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
 	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
 	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in Value.application(f.neutral!, x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)
-	"Successor": Value.forall { N in Value.forall { X in Value.pi(N) { n in Value.pi(.function(X, X)) { f in Value.pi(X) { x in .application(f.neutral!, .application(.application(n.neutral!, f), x)) } } } } }, // ∀ N . ∀ F . ∀ X . λ n : N . λ f : F . λ x : X . f ((n f) x)
+	"Successor": Value.forall { N in Value.forall { X in Value.pi(N) { n in Value.pi(.function(X, X)) { f in Value.pi(X) { x in f.apply(n.apply(f).apply(x)) } } } } }, // ∀ N . ∀ F . ∀ X . λ n : N . λ f : F . λ x : X . f ((n f) x)
 ])
 
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public let naturalEnvironment: Environment = [
-	"Natural": Value.forall(const(Value.forall(const(Value.forall(const(Value.forall(const(.Type)))))))),
+	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
 	"Zero": Value.forall { F in Value.forall { X in .pi(F, const(.pi(X, id))) } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . x
 	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
 ]

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -2,7 +2,7 @@
 
 public let naturalEnvironment: Environment = [
 	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
-	"Zero": Value.forall { F in Value.forall { X in .pi(F, const(.pi(X, id))) } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . x
+	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
 	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
 ]
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -3,6 +3,7 @@
 public let naturalEnvironment: Environment = [
 	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
 	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
+	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in Value.application(f.neutral!, x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)
 	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
 ]
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,0 +1,7 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public let naturalEnvironment: Environment = [
+	"Natural": .Type,
+	"Zero": Value.constant(0, .Free("Natural")),
+	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
+]

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public let naturalEnvironment: Environment = [
+public let naturalEnvironment: [Name: Value] = [
 	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
 	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
 	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in Value.application(f.neutral!, x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,11 +1,11 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public let naturalEnvironment: [Name: Value] = [
+public let naturalEnvironment: Environment = Environment([], [
 	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
 	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
 	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in Value.application(f.neutral!, x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)
 	"Successor": Value.forall { N in Value.forall { X in Value.pi(N) { n in Value.pi(.function(X, X)) { f in Value.pi(X) { x in .application(f.neutral!, .application(.application(n.neutral!, f), x)) } } } } }, // ∀ N . ∀ F . ∀ X . λ n : N . λ f : F . λ x : X . f ((n f) x)
-]
+])
 
 
 import Prelude

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -2,7 +2,7 @@
 
 public let naturalEnvironment: Environment = [
 	"Natural": .Type,
-	"Zero": Value.forall { F in Value.forall { X in Value.pi(F, const(Value.pi(X, id))) } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . x
+	"Zero": Value.forall { F in Value.forall { X in .pi(F, const(.pi(X, id))) } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . x
 	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
 ]
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public let naturalEnvironment: Environment = [
-	"Natural": .Type,
+	"Natural": Value.forall(const(Value.forall(const(Value.forall(const(Value.forall(const(.Type)))))))),
 	"Zero": Value.forall { F in Value.forall { X in .pi(F, const(.pi(X, id))) } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . x
 	"Successor": Value.pi(Value.Free("Natural")) { $0.constant.flatMap { i, t in (i as? Int).map { ($0 + 1, t) } }.map(Value.constant) ?? $0 },
 ]

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -3,7 +3,7 @@
 public let naturalEnvironment: Environment = Environment([], [
 	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
 	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
-	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in Value.application(f.neutral!, x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)
+	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in f.apply(x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)
 	"Successor": Value.forall { N in Value.forall { X in Value.pi(N) { n in Value.pi(.function(X, X)) { f in Value.pi(X) { x in f.apply(n.apply(f).apply(x)) } } } } }, // ∀ N . ∀ F . ∀ X . λ n : N . λ f : F . λ x : X . f ((n f) x)
 ])
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public let naturalEnvironment: Environment = Environment([], [
-	"Natural": Value.forall(const(Value.function(Value.function(.Type, .Type), Value.forall(const(.Type))))),
+	"Natural": Value.forall { X in Value.pi(Value.function(X, X), const(Value.pi(X, id))) },
 	"Zero": Value.forall { X in .pi(.function(X, X), const(.pi(X, id))) }, // ∀ X : Type . λ f : X → X . λ x : X . x
 	"One": Value.forall { X in Value.pi(.function(X, X)) { f in Value.pi(X) { x in f.apply(x) } } }, // ∀ F : Type . ∀ X : Type . λ f : F . λ x : X . f(x)
 	"Successor": Value.forall { N in Value.forall { X in Value.pi(N) { n in Value.pi(.function(X, X)) { f in Value.pi(X) { x in f.apply(n.apply(f).apply(x)) } } } } }, // ∀ N . ∀ F . ∀ X . λ n : N . λ f : F . λ x : X . f ((n f) x)

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -1,6 +1,20 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public enum Neutral: DebugPrintable {
+	// MARK: Quotation
+
+	func quote(n: Int) -> Term {
+		return analysis(
+			ifParameter: {
+				$0.analysis(
+					ifGlobal: const(Term.free($0)),
+					ifLocal: const(Term.free($0)),
+					ifQuote: Term.bound)
+			},
+			ifApplication: { Term.application($0.quote(n), $1.quote(n)) })
+	}
+
+
 	// MARK: Analyses
 
 	func analysis<T>(@noescape #ifParameter: Name -> T, @noescape ifApplication: (Neutral, Value) -> T) -> T {
@@ -30,3 +44,4 @@ public enum Neutral: DebugPrintable {
 
 
 import Box
+import Prelude

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -12,7 +12,7 @@ public enum Neutral: DebugPrintable {
 
 	public func quote(n: Int) -> Term {
 		return analysis(
-			ifParameter: {
+			ifFree: {
 				$0.analysis(
 					ifGlobal: const(Term.free($0)),
 					ifLocal: const(Term.free($0)),
@@ -24,10 +24,10 @@ public enum Neutral: DebugPrintable {
 
 	// MARK: Analyses
 
-	public func analysis<T>(@noescape #ifParameter: Name -> T, @noescape ifApplication: (Neutral, Value) -> T) -> T {
+	public func analysis<T>(@noescape #ifFree: Name -> T, @noescape ifApplication: (Neutral, Value) -> T) -> T {
 		switch self {
-		case let .Parameter(n):
-			return ifParameter(n)
+		case let .Free(n):
+			return ifFree(n)
 		case let .Application(n, v):
 			return ifApplication(n.value, v)
 		}
@@ -38,14 +38,14 @@ public enum Neutral: DebugPrintable {
 
 	public var debugDescription: String {
 		return analysis(
-			ifParameter: toDebugString,
+			ifFree: toDebugString,
 			ifApplication: { "\(toDebugString($0))(\(toDebugString($1)))" })
 	}
 
 
 	// MARK: Cases
 
-	case Parameter(Name)
+	case Free(Name)
 	case Application(Box<Neutral>, Value)
 }
 

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -1,6 +1,18 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public enum Neutral: DebugPrintable {
+	// MARK: Analyses
+
+	func analysis<T>(@noescape #ifParameter: Name -> T, @noescape ifApplication: (Neutral, Value) -> T) -> T {
+		switch self {
+		case let .Parameter(n):
+			return ifParameter(n)
+		case let .Application(n, v):
+			return ifApplication(n.value, v)
+		}
+	}
+
+
 	// MARK: DebugPrintable
 
 	public var debugDescription: String {

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -16,7 +16,7 @@ public enum Neutral: DebugPrintable {
 				$0.analysis(
 					ifGlobal: const(Term.free($0)),
 					ifLocal: const(Term.free($0)),
-					ifQuote: Term.bound)
+					ifQuote: { Term.bound(n - $0 - 1) })
 			},
 			ifApplication: { Term.application($0.quote(n), $1.quote(n)) })
 	}

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -3,14 +3,14 @@
 public enum Neutral: DebugPrintable {
 	// MARK: Constructors
 
-	static func application(f: Neutral, _ v: Value) -> Neutral {
+	public static func application(f: Neutral, _ v: Value) -> Neutral {
 		return .Application(Box(f), v)
 	}
 
 
 	// MARK: Quotation
 
-	func quote(n: Int) -> Term {
+	public func quote(n: Int) -> Term {
 		return analysis(
 			ifParameter: {
 				$0.analysis(
@@ -24,7 +24,7 @@ public enum Neutral: DebugPrintable {
 
 	// MARK: Analyses
 
-	func analysis<T>(@noescape #ifParameter: Name -> T, @noescape ifApplication: (Neutral, Value) -> T) -> T {
+	public func analysis<T>(@noescape #ifParameter: Name -> T, @noescape ifApplication: (Neutral, Value) -> T) -> T {
 		switch self {
 		case let .Parameter(n):
 			return ifParameter(n)

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -1,6 +1,13 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public enum Neutral: DebugPrintable {
+	// MARK: Constructors
+
+	static func application(f: Neutral, _ v: Value) -> Neutral {
+		return .Application(Box(f), v)
+	}
+
+
 	// MARK: Quotation
 
 	func quote(n: Int) -> Term {

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -1,0 +1,9 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+public enum Neutral {
+	case Parameter(Name)
+	case Application(Box<Neutral>, Value)
+}
+
+
+import Box

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -16,12 +16,9 @@ public enum Neutral: DebugPrintable {
 	// MARK: DebugPrintable
 
 	public var debugDescription: String {
-		switch self {
-		case let .Parameter(n):
-			return n.debugDescription
-		case let .Application(n, v):
-			return "\(toDebugString(n))(\(toDebugString(v)))"
-		}
+		return analysis(
+			ifParameter: toDebugString,
+			ifApplication: { "\(toDebugString($0))(\(toDebugString($1)))" })
 	}
 
 

--- a/Manifold/Neutral.swift
+++ b/Manifold/Neutral.swift
@@ -1,6 +1,20 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public enum Neutral {
+public enum Neutral: DebugPrintable {
+	// MARK: DebugPrintable
+
+	public var debugDescription: String {
+		switch self {
+		case let .Parameter(n):
+			return n.debugDescription
+		case let .Application(n, v):
+			return "\(toDebugString(n))(\(toDebugString(v)))"
+		}
+	}
+
+
+	// MARK: Cases
+
 	case Parameter(Name)
 	case Application(Box<Neutral>, Value)
 }

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -131,11 +131,11 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Evaluation
 
-	public func evaluate(_ environment: Environment = []) -> Value {
+	public func evaluate(_ environment: Environment = Environment()) -> Value {
 		return expression.analysis(
 			ifType: const(.Type),
 			ifBound: { i -> Value in
-				environment[i]
+				environment.local[i]
 			},
 			ifFree: { i -> Value in
 				.free(i)
@@ -144,10 +144,10 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				a.evaluate(environment).apply(b.evaluate(environment))
 			},
 			ifPi: { type, body -> Value in
-				Value.pi(type.evaluate(environment)) { body.evaluate([ $0 ] + environment) }
+				Value.pi(type.evaluate(environment)) { body.evaluate(environment.byPrepending($0)) }
 			},
 			ifSigma: { type, body -> Value in
-				Value.sigma(type.evaluate(environment)) { body.evaluate([ $0 ] + environment) }
+				Value.sigma(type.evaluate(environment)) { body.evaluate(environment.byPrepending($0)) }
 			})
 	}
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -27,7 +27,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		return Term(.Bound(i))
 	}
 
-	static func free(name: Name) -> Term {
+	public static func free(name: Name) -> Term {
 		return Term(.Free(name))
 	}
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -77,7 +77,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 	// MARK: Type-checking
 
 	public func typecheck() -> Either<Error, Value> {
-		return typecheck([], from: 0)
+		return typecheck([:], from: 0)
 	}
 
 	public func typecheck(context: Context, from i: Int) -> Either<Error, Value> {
@@ -104,7 +104,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				t.typecheck(context, from: i)
 					.flatMap { _ in
 						let t = t.evaluate()
-						return b.substitute(0, .free(.Local(i))).typecheck([ (.Local(i), t) ] + context, from: i + 1)
+						return b.substitute(0, .free(.Local(i))).typecheck([ .Local(i): t ] + context, from: i + 1)
 							.map { Value.function(t, $0) }
 					}
 			},
@@ -112,7 +112,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				t.typecheck(context, from: i)
 					.flatMap { _ in
 						let t = t.evaluate()
-						return b.substitute(0, .free(.Local(i))).typecheck([ (.Local(i), t) ] + context, from: i + 1)
+						return b.substitute(0, .free(.Local(i))).typecheck([ .Local(i): t ] + context, from: i + 1)
 							.map { Value.product(t, $0) }
 					}
 			})

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -40,12 +40,6 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			otherwise: const(false))
 	}
 
-	public var constant: (Any, Term)? {
-		return expression.analysis(
-			ifConstant: unit,
-			otherwise: const(nil))
-	}
-
 	public var bound: Int? {
 		return expression.analysis(
 			ifBound: unit,

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -64,6 +64,8 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Type-checking
 
+	public typealias Environment = [ Int: Value ]
+
 	public var freeVariables: Set<Int> {
 		return expression.analysis(
 			ifBound: { [ $0.0 ] },
@@ -73,7 +75,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			otherwise: const([]))
 	}
 
-	public func typecheck(_ environment: [Int: Value] = [:]) -> Either<Error, Value> {
+	public func typecheck(_ environment: Environment = [:]) -> Either<Error, Value> {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),
 			ifBound: { i -> Either<Error, Value> in
@@ -102,7 +104,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			})
 	}
 
-	public func typecheck(environment: [Int: Value], _ against: Value) -> Either<Error, Value> {
+	public func typecheck(environment: Environment, _ against: Value) -> Either<Error, Value> {
 		return typecheck(environment)
 			.flatMap { t in
 				let (q, r) = (t.quote, against.quote)
@@ -115,7 +117,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Evaluation
 
-	public func evaluate(_ environment: [Int: Value] = [:]) -> Either<Error, Value> {
+	public func evaluate(_ environment: Environment = [:]) -> Either<Error, Value> {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),
 			ifBound: { i -> Either<Error, Value> in

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -123,7 +123,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				environment[.Local(i)].map(Either.right) ?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
-				environment[i].map(Either.right) ?? Either.left("unexpected free variable \(i)")
+				.right(.parameter(i))
 			},
 			ifApplication: { a, b -> Either<Error, Value> in
 				(a.evaluate(environment) &&& b.evaluate(environment))

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -104,7 +104,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				t.typecheck(context, from: i)
 					.flatMap { _ in
 						let t = t.evaluate()
-						return b.typecheck([ (.Local(i), t) ] + context, from: i + 1)
+						return b.substitute(0, .free(.Local(i))).typecheck([ (.Local(i), t) ] + context, from: i + 1)
 							.map { Value.function(t, $0) }
 					}
 			},
@@ -112,7 +112,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				t.typecheck(context, from: i)
 					.flatMap { _ in
 						let t = t.evaluate()
-						return b.typecheck([ (.Local(i), t) ] + context, from: i + 1)
+						return b.substitute(0, .free(.Local(i))).typecheck([ (.Local(i), t) ] + context, from: i + 1)
 							.map { Value.product(t, $0) }
 					}
 			})

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -151,7 +151,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifType: const("Type"),
 			ifBound: { "Bound(\($0))" },
 			ifFree: { "Free(\($0))" },
-			ifApplication: { "(\($0)) (\($1))" },
+			ifApplication: { "\($0)(\($1))" },
 			ifPi: { "Π \($0) : \($1) . \($2)" },
 			ifSigma: { "Σ \($0) : \($1) . \($2)" })
 	}
@@ -191,7 +191,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifType: const("Type"),
 			ifBound: alphabetize,
 			ifFree: { $0.analysis(ifGlobal: id, ifLocal: alphabetize, ifQuote: alphabetize) },
-			ifApplication: { "(\($0.1)) (\($1.1))" },
+			ifApplication: { "\($0.1)(\($1.1))" },
 			ifPi: {
 				$2.0.freeVariables.contains($0)
 					? "Π \(alphabetize($0)) : \($1.1) . \($2.1)"

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -93,7 +93,8 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 					?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
-				environment[i].map(Either.right)
+				environment[i]
+					.map { $0.quote.typecheck(environment) }
 					?? Either.left("unexpected free variable \(i)")
 			},
 			ifApplication: { a, b -> Either<Error, Value> in

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -203,7 +203,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		let alphabetize: Int -> String = { index in Swift.toString(Term.alphabet[advance(Term.alphabet.startIndex, index)]) }
 		return expression.analysis(
 			ifType: const("Type"),
-			ifConstant: { "(\($0)) : \($1)" },
+			ifConstant: { "(\($0)) : \($1.1)" },
 			ifBound: alphabetize,
 			ifFree: { $0.analysis(ifGlobal: id, ifLocal: alphabetize, ifQuote: alphabetize) },
 			ifApplication: { "(\($0.1)) (\($1.1))" },

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -118,7 +118,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				.right(environment[i])
 			},
 			ifFree: { i -> Either<Error, Value> in
-				.right(.parameter(i))
+				.right(.free(i))
 			},
 			ifApplication: { a, b -> Either<Error, Value> in
 				(a.evaluate(environment) &&& b.evaluate(environment))

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -47,13 +47,13 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			otherwise: const(nil))
 	}
 
-	public var pi: (Int, Term, Term)? {
+	public var pi: (Term, Term)? {
 		return expression.analysis(
 			ifPi: unit,
 			otherwise: const(nil))
 	}
 
-	public var sigma: (Int, Term, Term)? {
+	public var sigma: (Term, Term)? {
 		return expression.analysis(
 			ifSigma: unit,
 			otherwise: const(nil))
@@ -64,54 +64,58 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Type-checking
 
-	public func typecheck(_ environment: Environment = [:]) -> Either<Error, Value> {
+	public func typecheck() -> Either<Error, Value> {
+		return typecheck([], from: 0)
+	}
+
+	public func typecheck(context: Context, from i: Int) -> Either<Error, Value> {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),
 			ifBound: { i -> Either<Error, Value> in
-				environment[.Local(i)].map(Either.right)
+				lookup(context, .Local(i)).map(Either.right)
 					?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
-				environment[i]
-					.map { $0.quote.typecheck(environment) }
+				lookup(context, i)
+					.map(Either.right)
 					?? Either.left("unexpected free variable \(i)")
 			},
 			ifApplication: { a, b -> Either<Error, Value> in
-				a.typecheck(environment)
+				a.typecheck(context, from: i)
 					.flatMap { t in
 						t.analysis(
-							ifPi: { v, f in b.typecheck(environment, v).flatMap(f) },
+							ifPi: { v, f in b.typecheck(context, against: v, from: i).flatMap(f) },
 							otherwise: const(Either.left("illegal application of \(a) : \(t) to \(b)")))
 					}
 			},
-			ifPi: { i, t, b -> Either<Error, Value> in
-				t.typecheck(environment, .Type)
-					.map { t in Value.Pi(Box(t)) { _ in b.typecheck(environment + [ .Local(i): t ]) } }
+			ifPi: { t, b -> Either<Error, Value> in
+				t.typecheck(context, against: .Type, from: i)
+					.map { t in Value.Pi(Box(t)) { _ in b.typecheck([ (.Local(i), t) ] + context, from: i) } }
 			},
-			ifSigma: { i, t, b -> Either<Error, Value> in
-				t.typecheck(environment, .Type)
-					.map { t in Value.Sigma(Box(t)) { _ in b.typecheck(environment + [ .Local(i): t ]) } }
+			ifSigma: { t, b -> Either<Error, Value> in
+				t.typecheck(context, against: .Type, from: i)
+					.map { t in Value.Sigma(Box(t)) { _ in b.typecheck([ (.Local(i), t) ] + context, from: i) } }
 			})
 	}
 
-	public func typecheck(environment: Environment, _ against: Value) -> Either<Error, Value> {
-		return typecheck(environment)
+	public func typecheck(context: Context, against: Value, from i: Int) -> Either<Error, Value> {
+		return typecheck(context, from: i)
 			.flatMap { t in
 				let (q, r) = (t.quote, against.quote)
 				return (q == r) || (r == .type && q == Value.function(.Type, .Type).quote)
 					? Either.right(t)
-					: Either.left("type mismatch: expected (\(toDebugString(self))) : (\(toDebugString(r))), actually (\(toDebugString(self))) : (\(toDebugString(q))) in environment \(environment)")
+					: Either.left("type mismatch: expected (\(toDebugString(self))) : (\(toDebugString(r))), actually (\(toDebugString(self))) : (\(toDebugString(q))) in environment \(context)")
 			}
 	}
 
 
 	// MARK: Evaluation
 
-	public func evaluate(_ environment: Environment = [:]) -> Either<Error, Value> {
+	public func evaluate(_ environment: Environment = []) -> Either<Error, Value> {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),
 			ifBound: { i -> Either<Error, Value> in
-				environment[.Local(i)].map(Either.right) ?? Either.left("unexpectedly free bound variable \(i)")
+				.right(environment[i])
 			},
 			ifFree: { i -> Either<Error, Value> in
 				.right(.parameter(i))
@@ -120,13 +124,13 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				(a.evaluate(environment) &&& b.evaluate(environment))
 					.flatMap { $0.apply($1) }
 			},
-			ifPi: { i, type, body -> Either<Error, Value> in
+			ifPi: { type, body -> Either<Error, Value> in
 				type.evaluate(environment)
-					.map { type in Value.Pi(Box(type)) { body.evaluate(environment + [ .Local(i): $0 ]) } }
+					.map { type in Value.Pi(Box(type)) { body.evaluate([ $0 ] + environment) } }
 			},
-			ifSigma: { i, type, body -> Either<Error, Value> in
+			ifSigma: { type, body -> Either<Error, Value> in
 				type.evaluate(environment)
-					.map { type in Value.Sigma(Box(type)) { body.evaluate(environment + [ .Local(i): $0 ]) } }
+					.map { type in Value.Sigma(Box(type)) { body.evaluate([ $0 ] + environment) } }
 			})
 	}
 
@@ -143,8 +147,8 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifBound: { "Bound(\($0))" },
 			ifFree: { "Free(\($0))" },
 			ifApplication: { "\($0)(\($1))" },
-			ifPi: { "Π \($0) : \($1) . \($2)" },
-			ifSigma: { "Σ \($0) : \($1) . \($2)" })
+			ifPi: { "Π \($0) . \($1)" },
+			ifSigma: { "Σ \($0) . \($1)" })
 	}
 
 
@@ -163,8 +167,8 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifBound: { 3 ^ $0.hashValue },
 			ifFree: { 5 ^ $0.hashValue },
 			ifApplication: { 7 ^ $0.hashValue ^ $1.hashValue },
-			ifPi: { 11 ^ $0.hashValue ^ $1.hashValue ^ $2.hashValue },
-			ifSigma: { 13 ^ $0.hashValue ^ $1.hashValue ^ $2.hashValue })
+			ifPi: { 11 ^ $0.hashValue ^ $1.hashValue },
+			ifSigma: { 13 ^ $0.hashValue ^ $1.hashValue })
 	}
 
 
@@ -184,14 +188,10 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifFree: { $0.analysis(ifGlobal: id, ifLocal: alphabetize, ifQuote: alphabetize) },
 			ifApplication: { "\($0.1)(\($1.1))" },
 			ifPi: {
-				$2.0.freeVariables.contains($0)
-					? "Π \(alphabetize($0)) : \($1.1) . \($2.1)"
-					: "(\($1.1)) → \($2.1)"
+				"Π : \($0.1) . \($1.1)"
 			},
 			ifSigma: {
-				$2.0.freeVariables.contains($0)
-					? "Σ \(alphabetize($0)) : \($1.1) . \($2.1)"
-					: "(\($1.1) ✕ \($2.1))"
+				"Σ \($0.1) . \($1.1)"
 			})
 	}
 }

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
-	public init(_ expression: Expression<Term>) {
+	public init(_ expression: Checkable<Term>) {
 		self.expression = expression
 	}
 
@@ -59,7 +59,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			otherwise: const(nil))
 	}
 
-	public let expression: Expression<Term>
+	public let expression: Checkable<Term>
 
 
 	// MARK: Type-checking
@@ -146,7 +146,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		return cata(Term.toDebugString)(self)
 	}
 
-	private static func toDebugString(expression: Expression<String>) -> String {
+	private static func toDebugString(expression: Checkable<String>) -> String {
 		return expression.analysis(
 			ifType: const("Type"),
 			ifBound: { "Bound(\($0))" },
@@ -159,7 +159,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: FixpointType
 
-	public var out: Expression<Term> {
+	public var out: Checkable<Term> {
 		return expression
 	}
 
@@ -185,7 +185,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	private static let alphabet = "abcdefghijklmnopqrstuvwxyz"
 
-	private static func toString(expression: Expression<(Term, String)>) -> String {
+	private static func toString(expression: Checkable<(Term, String)>) -> String {
 		let alphabetize: Int -> String = { index in Swift.toString(Term.alphabet[advance(Term.alphabet.startIndex, index)]) }
 		return expression.analysis(
 			ifType: const("Type"),

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -191,7 +191,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		return expression.analysis(
 			ifType: const("Type"),
 			ifBound: alphabetize,
-			ifFree: Name.value >>> alphabetize,
+			ifFree: { $0.analysis(ifGlobal: id, ifLocal: alphabetize, ifQuote: alphabetize) },
 			ifApplication: { "(\($0.1)) (\($1.1))" },
 			ifPi: {
 				$2.0.freeVariables.contains($0)

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -64,8 +64,6 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Type-checking
 
-	public typealias Environment = [ Name: Value ]
-
 	public var freeVariables: Set<Int> {
 		return expression.analysis(
 			ifBound: { [ $0.0 ] },

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -138,7 +138,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 				environment.local[i]
 			},
 			ifFree: { i -> Value in
-				.free(i)
+				environment.global[i] ?? .free(i)
 			},
 			ifApplication: { a, b -> Value in
 				a.evaluate(environment).apply(b.evaluate(environment))

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -62,6 +62,18 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 	public let expression: Checkable<Term>
 
 
+	// MARK: Substitution
+
+	public func substitute(i: Int, _ term: Term) -> Term {
+		return expression.analysis(
+			ifBound: { i == $0 ? term : self },
+			ifApplication: { Term.application($0.substitute(i, term), $1.substitute(i, term)) },
+			ifPi: { Term(.Pi(Box($0.substitute(i, term)), Box($1.substitute(i + 1, term)))) },
+			ifSigma: { Term(.Sigma(Box($0.substitute(i, term)), Box($1.substitute(i + 1, term)))) },
+			otherwise: const(self))
+	}
+
+
 	// MARK: Type-checking
 
 	public func typecheck() -> Either<Error, Value> {

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -64,15 +64,6 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 
 	// MARK: Type-checking
 
-	public var freeVariables: Set<Int> {
-		return expression.analysis(
-			ifBound: { [ $0.0 ] },
-			ifApplication: { $0.freeVariables.union($1.freeVariables) },
-			ifPi: { i, type, body in type.freeVariables.union(body.freeVariables).subtract([ i ]) },
-			ifSigma: { i, type, body in type.freeVariables.union(body.freeVariables).subtract([ i ]) },
-			otherwise: const([]))
-	}
-
 	public func typecheck(_ environment: Environment = [:]) -> Either<Error, Value> {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -90,7 +90,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifConstant: { $1.typecheck(environment) },
 			ifBound: { i -> Either<Error, Value> in
 				environment[.Local(i)].map(Either.right)
-					?? Either.left("unexpected free variable \(i)")
+					?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
 				environment[i].map(Either.right)
@@ -132,7 +132,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			ifType: const(Either.right(.Type)),
 			ifConstant: { $1.evaluate(environment).map(curry(Value.constant)($0)) },
 			ifBound: { i -> Either<Error, Value> in
-				environment[.Local(i)].map(Either.right) ?? Either.left("unexpected free variable \(i)")
+				environment[.Local(i)].map(Either.right) ?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
 				environment[i].map(Either.right) ?? Either.left("unexpected free variable \(i)")

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -107,7 +107,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		return typecheck(environment)
 			.flatMap { t in
 				let (q, r) = (t.quote, against.quote)
-				return q == r
+				return (q == r) || (r == .type && q == Value.function(.Type, .Type).quote)
 					? Either.right(t)
 					: Either.left("type mismatch: expected (\(toDebugString(self))) : (\(toDebugString(r))), actually (\(toDebugString(self))) : (\(toDebugString(q))) in environment \(environment)")
 			}

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -40,6 +40,12 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			otherwise: const(false))
 	}
 
+	public var constant: (Any, Term)? {
+		return expression.analysis(
+			ifConstant: unit,
+			otherwise: const(nil))
+	}
+
 	public var bound: Int? {
 		return expression.analysis(
 			ifBound: unit,

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -84,11 +84,11 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		return expression.analysis(
 			ifType: const(Either.right(.Type)),
 			ifBound: { i -> Either<Error, Value> in
-				lookup(context, .Local(i)).map(Either.right)
+				context[.Local(i)].map(Either.right)
 					?? Either.left("unexpectedly free bound variable \(i)")
 			},
 			ifFree: { i -> Either<Error, Value> in
-				lookup(context, i)
+				context[i]
 					.map(Either.right)
 					?? Either.left("unexpected free variable \(i)")
 			},

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -204,7 +204,7 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 		let alphabetize: Int -> String = { index in Swift.toString(Term.alphabet[advance(Term.alphabet.startIndex, index)]) }
 		return expression.analysis(
 			ifType: const("Type"),
-			ifConstant: { "(\($0)) : \($1.1)" },
+			ifConstant: { "(\($0)) : \($1)" },
 			ifBound: alphabetize,
 			ifFree: { $0.analysis(ifGlobal: id, ifLocal: alphabetize, ifQuote: alphabetize) },
 			ifApplication: { "(\($0.1)) (\($1.1))" },

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -84,12 +84,12 @@ public enum Value: DebugPrintable {
 					ifQuote: Term.bound)
 			},
 			ifPi: { type, f in
-				f(.Free(.Quote(n))).either(
+				f(.parameter(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
 					ifRight: { Term(Expression.Pi(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},
 			ifSigma: { type, f in
-				f(.Free(.Quote(n))).either(
+				f(.parameter(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
 					ifRight: { Term(Expression.Sigma(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -26,8 +26,8 @@ public enum Value: DebugPrintable {
 		return .neutral(.application(f, v))
 	}
 
-	public static func parameter(name: Name) -> Value {
-		return .neutral(.Parameter(name))
+	public static func free(name: Name) -> Value {
+		return .neutral(.Free(name))
 	}
 
 	public static func neutral(value: Manifold.Neutral) -> Value {
@@ -83,12 +83,12 @@ public enum Value: DebugPrintable {
 		return analysis(
 			ifType: const(.type),
 			ifPi: { type, f in
-				f(.parameter(.Quote(n))).either(
+				f(.free(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
 					ifRight: { Term(Checkable.Pi(Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},
 			ifSigma: { type, f in
-				f(.parameter(.Quote(n))).either(
+				f(.free(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
 					ifRight: { Term(Checkable.Sigma(Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -85,12 +85,12 @@ public enum Value: DebugPrintable {
 			ifPi: { type, f in
 				f(.parameter(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
-					ifRight: { Term(Expression.Pi(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
+					ifRight: { Term(Checkable.Pi(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},
 			ifSigma: { type, f in
 				f(.parameter(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
-					ifRight: { Term(Expression.Sigma(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
+					ifRight: { Term(Checkable.Sigma(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},
 			ifNeutral: {
 				$0.quote(n)

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -27,6 +27,12 @@ public enum Value: DebugPrintable {
 			otherwise: const(false))
 	}
 
+	public var constant: (Any, Value)? {
+		return analysis(
+			ifConstant: unit,
+			otherwise: const(nil))
+	}
+
 	public var pi: (Value, Value -> Either<Error, Value>)? {
 		return analysis(
 			ifPi: unit,

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -38,6 +38,10 @@ public enum Value: DebugPrintable {
 		return .Neutral(Box(value))
 	}
 
+	public static var type: Value {
+		return .Type
+	}
+
 
 	// MARK: Destructors
 

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -31,12 +31,6 @@ public enum Value: DebugPrintable {
 			otherwise: const(false))
 	}
 
-	public var constant: (Any, Value)? {
-		return analysis(
-			ifConstant: unit,
-			otherwise: const(nil))
-	}
-
 	public var free: Name? {
 		return analysis(
 			ifFree: unit,

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -18,6 +18,10 @@ public enum Value: DebugPrintable {
 		return .pi(.Type, f)
 	}
 
+	public static func neutral(value: Manifold.Neutral) -> Value {
+		return .Neutral(Box(value))
+	}
+
 
 	// MARK: Destructors
 

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -18,6 +18,10 @@ public enum Value: DebugPrintable {
 		return .pi(.Type, f)
 	}
 
+	public static func function(from: Value, _ to: Value) -> Value {
+		return .pi(from, const(to))
+	}
+
 	public static func application(f: Manifold.Neutral, _ v: Value) -> Value {
 		return .neutral(.application(f, v))
 	}

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -22,6 +22,10 @@ public enum Value: DebugPrintable {
 		return .pi(from, const(to))
 	}
 
+	public static func product(a: Value, _ b: Value) -> Value {
+		return .sigma(a, const(b))
+	}
+
 	public static func application(f: Manifold.Neutral, _ v: Value) -> Value {
 		return .neutral(.application(f, v))
 	}

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -68,6 +68,7 @@ public enum Value: DebugPrintable {
 		return analysis(
 			ifPi: { _, f in f(other) },
 			ifSigma: { _, f in f(other) },
+			ifNeutral: { .right(.neutral(.application($0, other))) },
 			otherwise: const(Either.left("illegal application of \(self) to \(other)")))
 	}
 

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -18,6 +18,10 @@ public enum Value: DebugPrintable {
 		return .Sigma(Box(value), f >>> Either.right)
 	}
 
+	public static func forall(f: Value -> Value) -> Value {
+		return .pi(.Type, f)
+	}
+
 
 	// MARK: Destructors
 

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -39,12 +39,6 @@ public enum Value: DebugPrintable {
 			otherwise: const(false))
 	}
 
-	public var free: Name? {
-		return analysis(
-			ifFree: unit,
-			otherwise: const(nil))
-	}
-
 	public var pi: (Value, Value -> Either<Error, Value>)? {
 		return analysis(
 			ifPi: unit,

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -45,6 +45,12 @@ public enum Value: DebugPrintable {
 			otherwise: const(nil))
 	}
 
+	public var neutral: Manifold.Neutral? {
+		return analysis(
+			ifNeutral: unit,
+			otherwise: const(nil))
+	}
+
 
 	// MARK: Application
 

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -33,6 +33,12 @@ public enum Value: DebugPrintable {
 			otherwise: const(nil))
 	}
 
+	public var free: Name? {
+		return analysis(
+			ifFree: unit,
+			otherwise: const(nil))
+	}
+
 	public var pi: (Value, Value -> Either<Error, Value>)? {
 		return analysis(
 			ifPi: unit,

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -62,7 +62,7 @@ public enum Value: DebugPrintable {
 		return quote(0)
 	}
 
-	private func quote(n: Int) -> Term {
+	func quote(n: Int) -> Term {
 		return analysis(
 			ifType: const(.type),
 			ifFree: {

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -57,6 +57,7 @@ public enum Value: DebugPrintable {
 			ifType: const(.type),
 			ifFree: {
 				$0.analysis(
+					ifGlobal: const(Term.free($0)),
 					ifLocal: const(Term.free($0)),
 					ifQuote: Term.bound)
 			},

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -86,12 +86,12 @@ public enum Value: DebugPrintable {
 			},
 			ifPi: { type, f in
 				f(.Free(.Quote(n))).either(
-					ifLeft: { x in assert(false, "\(toString(x)) in \(self)") ; return Term.type },
+					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
 					ifRight: { Term(Expression.Pi(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},
 			ifSigma: { type, f in
 				f(.Free(.Quote(n))).either(
-					ifLeft: { x in assert(false, "\(toString(x)) in \(self)") ; return Term.type },
+					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
 					ifRight: { Term(Expression.Sigma(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			})
 	}

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -18,6 +18,10 @@ public enum Value: DebugPrintable {
 		return .pi(.Type, f)
 	}
 
+	public static func application(f: Manifold.Neutral, _ v: Value) -> Value {
+		return .neutral(.application(f, v))
+	}
+
 	public static func neutral(value: Manifold.Neutral) -> Value {
 		return .Neutral(Box(value))
 	}

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -85,12 +85,12 @@ public enum Value: DebugPrintable {
 			ifPi: { type, f in
 				f(.parameter(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
-					ifRight: { Term(Checkable.Pi(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
+					ifRight: { Term(Checkable.Pi(Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},
 			ifSigma: { type, f in
 				f(.parameter(.Quote(n))).either(
 					ifLeft: { x in assert(false, "\(x) in \(self)") ; return Term.type },
-					ifRight: { Term(Checkable.Sigma(n, Box(type.quote(n)), Box($0.quote(n + 1)))) })
+					ifRight: { Term(Checkable.Sigma(Box(type.quote(n)), Box($0.quote(n + 1)))) })
 			},
 			ifNeutral: {
 				$0.quote(n)

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -22,6 +22,10 @@ public enum Value: DebugPrintable {
 		return .neutral(.application(f, v))
 	}
 
+	public static func parameter(name: Name) -> Value {
+		return .neutral(.Parameter(name))
+	}
+
 	public static func neutral(value: Manifold.Neutral) -> Value {
 		return .Neutral(Box(value))
 	}

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -8,21 +8,21 @@ final class NaturalTests: XCTestCase {
 		assert(value?.quote, ==, type.quote)
 	}
 
-	func testReferencesToOneAreWellTyped() {
-		let value = One.typecheck(naturalEnvironment.global, from: 0).right
-		let type = Natural.evaluate(naturalEnvironment)
-		assert(value, !=, nil)
-		assert(type, !=, nil)
-		assert(value?.quote, ==, type.quote)
-	}
-
-	func testSuccessorOfZeroIsOne() {
-		let value = Term.application(Successor, Zero).evaluate(naturalEnvironment)
-		let one = One.evaluate(naturalEnvironment)
-		assert(value, !=, nil)
-		assert(one, !=, nil)
-		assert(value.quote, ==, one.quote)
-	}
+//	func testReferencesToOneAreWellTyped() {
+//		let value = One.typecheck(naturalEnvironment.global, from: 0).right
+//		let type = Natural.evaluate(naturalEnvironment)
+//		assert(value, !=, nil)
+//		assert(type, !=, nil)
+//		assert(value?.quote, ==, type.quote)
+//	}
+//
+//	func testSuccessorOfZeroIsOne() {
+//		let value = Term.application(Successor, Zero).evaluate(naturalEnvironment)
+//		let one = One.evaluate(naturalEnvironment)
+//		assert(value, !=, nil)
+//		assert(one, !=, nil)
+//		assert(value.quote, ==, one.quote)
+//	}
 }
 
 let Natural = Term.free("Natural")

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -1,0 +1,22 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class NaturalTests: XCTestCase {
+	func testReferencesToZeroAreWellTyped() {
+		let value = Zero.typecheck(naturalEnvironment).right
+		assert(value, !=, nil)
+		assert(value?.quote, ==, .type)
+	}
+
+	func testReferencesToZeroEvaluateToConstantValueOfZero() {
+		let result = Zero.evaluate(naturalEnvironment)
+		let constant = result.right?.constant
+		assert(constant?.0 as? Int, ==, 0)
+	}
+}
+
+let Zero = Term.free("Zero")
+
+
+import Assertions
+import Manifold
+import XCTest

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -15,11 +15,20 @@ final class NaturalTests: XCTestCase {
 		assert(type, !=, nil)
 		assert(value?.quote, ==, type.quote)
 	}
+
+	func testSuccessorOfZeroIsOne() {
+		let value = Term.application(Successor, Zero).evaluate(naturalEnvironment)
+		let one = One.evaluate(naturalEnvironment)
+		assert(value, !=, nil)
+		assert(one, !=, nil)
+		assert(value.quote, ==, one.quote)
+	}
 }
 
 let Natural = Term.free("Natural")
 let Zero = Term.free("Zero")
 let One = Term.free("One")
+let Successor = Term.free("Successor")
 
 
 import Assertions

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -1,14 +1,13 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class NaturalTests: XCTestCase {
-//	func testReferencesToZeroAreWellTyped() {
-//		let value = Zero.typecheck(naturalEnvironment).right
-//		let type = Natural.evaluate(naturalEnvironment).right
-//		assert(value, !=, nil)
-//		assert(type, !=, nil)
-//		assert(value?.quote, ==, type?.quote)
-//	}
-//
+	func testReferencesToZeroAreWellTyped() {
+		let value = Zero.typecheck(naturalEnvironment.global, from: 0).right
+		let type = Natural.evaluate(naturalEnvironment)
+		assert(value, !=, nil)
+		assert(value?.quote, ==, type.quote)
+	}
+
 //	func testReferencesToOneAreWellTyped() {
 //		let value = One.typecheck(naturalEnvironment).right
 //		let type = Natural.evaluate(naturalEnvironment).right

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -8,10 +8,19 @@ final class NaturalTests: XCTestCase {
 		assert(type, !=, nil)
 		assert(value?.quote, ==, type?.quote)
 	}
+
+	func testReferencesToOneAreWellTyped() {
+		let value = One.typecheck(naturalEnvironment).right
+		let type = Natural.evaluate(naturalEnvironment).right
+		assert(value, !=, nil)
+		assert(type, !=, nil)
+		assert(value?.quote, ==, type?.quote)
+	}
 }
 
 let Natural = Term.free("Natural")
 let Zero = Term.free("Zero")
+let One = Term.free("One")
 
 
 import Assertions

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -3,11 +3,14 @@
 final class NaturalTests: XCTestCase {
 	func testReferencesToZeroAreWellTyped() {
 		let value = Zero.typecheck(naturalEnvironment).right
+		let type = Natural.evaluate(naturalEnvironment).right
 		assert(value, !=, nil)
-		assert(value?.quote, ==, .type)
+		assert(type, !=, nil)
+		assert(value?.quote, ==, type?.quote)
 	}
 }
 
+let Natural = Term.free("Natural")
 let Zero = Term.free("Zero")
 
 

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -6,12 +6,6 @@ final class NaturalTests: XCTestCase {
 		assert(value, !=, nil)
 		assert(value?.quote, ==, .type)
 	}
-
-	func testReferencesToZeroEvaluateToConstantValueOfZero() {
-		let result = Zero.evaluate(naturalEnvironment)
-		let constant = result.right?.constant
-		assert(constant?.0 as? Int, ==, 0)
-	}
 }
 
 let Zero = Term.free("Zero")

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -8,13 +8,13 @@ final class NaturalTests: XCTestCase {
 		assert(value?.quote, ==, type.quote)
 	}
 
-//	func testReferencesToOneAreWellTyped() {
-//		let value = One.typecheck(naturalEnvironment).right
-//		let type = Natural.evaluate(naturalEnvironment).right
-//		assert(value, !=, nil)
-//		assert(type, !=, nil)
-//		assert(value?.quote, ==, type?.quote)
-//	}
+	func testReferencesToOneAreWellTyped() {
+		let value = One.typecheck(naturalEnvironment.global, from: 0).right
+		let type = Natural.evaluate(naturalEnvironment)
+		assert(value, !=, nil)
+		assert(type, !=, nil)
+		assert(value?.quote, ==, type.quote)
+	}
 }
 
 let Natural = Term.free("Natural")

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -1,21 +1,21 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class NaturalTests: XCTestCase {
-	func testReferencesToZeroAreWellTyped() {
-		let value = Zero.typecheck(naturalEnvironment).right
-		let type = Natural.evaluate(naturalEnvironment).right
-		assert(value, !=, nil)
-		assert(type, !=, nil)
-		assert(value?.quote, ==, type?.quote)
-	}
-
-	func testReferencesToOneAreWellTyped() {
-		let value = One.typecheck(naturalEnvironment).right
-		let type = Natural.evaluate(naturalEnvironment).right
-		assert(value, !=, nil)
-		assert(type, !=, nil)
-		assert(value?.quote, ==, type?.quote)
-	}
+//	func testReferencesToZeroAreWellTyped() {
+//		let value = Zero.typecheck(naturalEnvironment).right
+//		let type = Natural.evaluate(naturalEnvironment).right
+//		assert(value, !=, nil)
+//		assert(type, !=, nil)
+//		assert(value?.quote, ==, type?.quote)
+//	}
+//
+//	func testReferencesToOneAreWellTyped() {
+//		let value = One.typecheck(naturalEnvironment).right
+//		let type = Natural.evaluate(naturalEnvironment).right
+//		assert(value, !=, nil)
+//		assert(type, !=, nil)
+//		assert(value?.quote, ==, type?.quote)
+//	}
 }
 
 let Natural = Term.free("Natural")

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -57,6 +57,15 @@ final class TermTests: XCTestCase {
 		assert(value.right?.quote, ==, identity)
 		assert(value.left, ==, nil)
 	}
+
+
+	func testGlobalsPrintTheirNames() {
+		assert(Term(.Free("Global")).description, ==, "Global")
+	}
+
+	func testConstantsPrintTheirValueAndType() {
+		assert(Term.constant(0, Term(.Free("Global"))).description, ==, "(0) : Global")
+	}
 }
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -6,7 +6,7 @@ final class TermTests: XCTestCase {
 	}
 
 	func testHigherOrderConstruction() {
-		let expected = Term(.Pi(Box(.type), Box(Term(.Pi(Box(Term(.Bound(0))), Box(Term(.Bound(1))))))))
+		let expected = Term(.Pi(Box(.type), Box(Term(.Pi(Box(Term(.Bound(0))), Box(Term(.Bound(0))))))))
 		assert(identity, ==, expected)
 	}
 
@@ -14,12 +14,12 @@ final class TermTests: XCTestCase {
 //		assert(identity.typecheck().right?.quote, ==, Value.pi(.Type, const(.pi(.Type, const(.Type)))).quote)
 	}
 
-	func testFunctionTypesArePrintedWithAnArrow() {
-//		assert(identity.typecheck().right?.quote.description, ==, "(Type) → (Type) → Type")
+	func testPiTypeDescription() {
+		assert(identity.typecheck().right?.quote.description, ==, "Π : Type . Π : a . a")
 	}
 
-	func testProductTypesArePrintedWithAnX() {
-		assert(Value.sigma(.Type, const(.Type)).quote.typecheck().right?.quote.description, ==, "(Type ✕ Type)")
+	func testSigmaTypeDescription() {
+		assert(Value.sigma(.Type, const(.Type)).quote.typecheck().right?.quote.description, ==, "Σ Type . Type")
 	}
 
 	func testTypeOfTypeIsType() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -11,7 +11,7 @@ final class TermTests: XCTestCase {
 	}
 
 	func testTypechecking() {
-//		assert(identity.typecheck().right?.quote, ==, Value.pi(.Type, const(.pi(.Type, const(.Type)))).quote)
+		assert(identity.typecheck().right?.quote, ==, Value.pi(.Type, const(.pi(.free(0), const(.free(0))))).quote)
 	}
 
 	func testPiTypeDescription() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -32,7 +32,7 @@ final class TermTests: XCTestCase {
 
 
 	func testBoundVariablesEvaluateToTheValueBoundInTheEnvironment() {
-		assert(Term(.Bound(2)).evaluate([ 2: .Type ]).right?.quote, ==, Term.type)
+		assert(Term(.Bound(2)).evaluate([ .Local(2): .Type ]).right?.quote, ==, Term.type)
 	}
 
 	func testTrivialAbstractionEvaluatesToItself() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -32,7 +32,7 @@ final class TermTests: XCTestCase {
 
 
 	func testBoundVariablesEvaluateToTheValueBoundInTheEnvironment() {
-		assert(Term(.Bound(2)).evaluate([ .Local(2): .Type ]).right?.quote, ==, Term.type)
+		assert(Term(.Bound(2)).evaluate([ .forall(id), .forall(id), .Type ]).right?.quote, ==, Term.type)
 	}
 
 	func testTrivialAbstractionEvaluatesToItself() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -11,11 +11,11 @@ final class TermTests: XCTestCase {
 	}
 
 	func testTypechecking() {
-		assert(identity.typecheck().right?.quote, ==, Value.pi(.Type, const(.pi(.Type, const(.Type)))).quote)
+//		assert(identity.typecheck().right?.quote, ==, Value.pi(.Type, const(.pi(.Type, const(.Type)))).quote)
 	}
 
 	func testFunctionTypesArePrintedWithAnArrow() {
-		assert(identity.typecheck().right?.quote.description, ==, "(Type) → (Type) → Type")
+//		assert(identity.typecheck().right?.quote.description, ==, "(Type) → (Type) → Type")
 	}
 
 	func testProductTypesArePrintedWithAnX() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -32,7 +32,7 @@ final class TermTests: XCTestCase {
 
 
 	func testBoundVariablesEvaluateToTheValueBoundInTheEnvironment() {
-		assert(Term(.Bound(2)).evaluate([ .forall(id), .forall(id), .Type ]).quote, ==, Term.type)
+		assert(Term(.Bound(2)).evaluate(Environment([ .forall(id), .forall(id), .Type ])).quote, ==, Term.type)
 	}
 
 	func testTrivialAbstractionEvaluatesToItself() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -2,11 +2,11 @@
 
 final class TermTests: XCTestCase {
 	func testTrivialHigherOrderConstruction() {
-		assert(Value.pi(.Type, id).quote, ==, Term(.Pi(0, Box(.type), Box(Term(.Bound(0))))))
+		assert(Value.pi(.Type, id).quote, ==, Term(.Pi(Box(.type), Box(Term(.Bound(0))))))
 	}
 
 	func testHigherOrderConstruction() {
-		let expected = Term(.Pi(0, Box(.type), Box(Term(.Pi(1, Box(Term(.Bound(0))), Box(Term(.Bound(1))))))))
+		let expected = Term(.Pi(Box(.type), Box(Term(.Pi(Box(Term(.Bound(0))), Box(Term(.Bound(1))))))))
 		assert(identity, ==, expected)
 	}
 
@@ -27,7 +27,7 @@ final class TermTests: XCTestCase {
 	}
 
 	func testTypeOfAbstractionIsAbstractionType() {
-		assert(Value.pi(.Type, id).quote.typecheck().right?.quote, ==, Term(.Pi(0, Box(.type), Box(.type))))
+		assert(Value.pi(.Type, id).quote.typecheck().right?.quote, ==, Term(.Pi(Box(.type), Box(.type))))
 	}
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -53,9 +53,9 @@ final class TermTests: XCTestCase {
 	}
 
 	func testEvaluation() {
-//		let value = identity.typecheck().map { Term.application(Term.application(identity, $0.quote), identity).evaluate() }
-//		assert(value.right?.quote, ==, identity)
-//		assert(value.left, ==, nil)
+		let value = identity.typecheck().map { Term.application(Term.application(identity, $0.quote), identity).evaluate() }
+		assert(value.right?.quote, ==, identity)
+		assert(value.left, ==, nil)
 	}
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -32,30 +32,30 @@ final class TermTests: XCTestCase {
 
 
 	func testBoundVariablesEvaluateToTheValueBoundInTheEnvironment() {
-		assert(Term(.Bound(2)).evaluate([ .forall(id), .forall(id), .Type ]).right?.quote, ==, Term.type)
+		assert(Term(.Bound(2)).evaluate([ .forall(id), .forall(id), .Type ]).quote, ==, Term.type)
 	}
 
 	func testTrivialAbstractionEvaluatesToItself() {
 		let lambda = Value.pi(.Type, id).quote
-		assert(lambda.evaluate().right?.quote, ==, lambda)
+		assert(lambda.evaluate().quote, ==, lambda)
 	}
 
 	func testAbstractionEvaluatesToItself() {
-		assert(identity.evaluate().right?.quote, ==, identity)
+		assert(identity.evaluate().quote, ==, identity)
 	}
 
 	func testTypeEvaluatesToItself() {
-		assert(Term.type.evaluate().right?.quote, ==, Term.type)
+		assert(Term.type.evaluate().quote, ==, Term.type)
 	}
 
 	func testApplicationEvaluation() {
-		assert(Term.application(Value.pi(.Type, id).quote, .type).evaluate().right?.quote, ==, .type)
+		assert(Term.application(Value.pi(.Type, id).quote, .type).evaluate().quote, ==, .type)
 	}
 
 	func testEvaluation() {
-		let value = identity.typecheck().flatMap { Term.application(Term.application(identity, $0.quote), identity).evaluate() }
-		assert(value.right?.quote, ==, identity)
-		assert(value.left, ==, nil)
+//		let value = identity.typecheck().map { Term.application(Term.application(identity, $0.quote), identity).evaluate() }
+//		assert(value.right?.quote, ==, identity)
+//		assert(value.left, ==, nil)
 	}
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -62,10 +62,6 @@ final class TermTests: XCTestCase {
 	func testGlobalsPrintTheirNames() {
 		assert(Term(.Free("Global")).description, ==, "Global")
 	}
-
-	func testConstantsPrintTheirValueAndType() {
-		assert(Term.constant(0, Term(.Free("Global"))).description, ==, "(0) : Global")
-	}
 }
 
 

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -10,7 +10,7 @@ final class ValueTests: XCTestCase {
 	}
 
 	func testQuotationMapsQuotedVariablesToBoundVariables() {
-		assert(Value.Free(.Quote(1)).quote, ==, Term(.Bound(1)))
+		assert(Value.parameter(.Quote(1)).quote, ==, Term(.Bound(1)))
 	}
 
 	func testQuotationMapsNestedBoundVariablesToBoundVariables() {

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -6,15 +6,11 @@ final class ValueTests: XCTestCase {
 	}
 
 	func testNestedQuotation() {
-		assert(Value.pi(.Type) { Value.pi(.Type, const($0)) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(0)))))))))
-	}
-
-	func testQuotationMapsQuotedVariablesToBoundVariables() {
-		assert(Value.free(.Quote(1)).quote, ==, Term(.Bound(1)))
+		assert(Value.pi(.Type) { Value.pi(.Type, const($0)) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(1)))))))))
 	}
 
 	func testQuotationMapsNestedBoundVariablesToBoundVariables() {
-		assert(Value.pi(.type) { _ in Value.pi(.type, id) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(1)))))))))
+		assert(Value.pi(.type) { _ in Value.pi(.type, id) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(0)))))))))
 	}
 }
 

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -6,7 +6,7 @@ final class ValueTests: XCTestCase {
 	}
 
 	func testNestedQuotation() {
-		assert(Value.pi(.Type) { Value.pi(.Type, const($0)) }.quote, ==, Term(.Pi(0, Box(.type), Box(Term(.Pi(1, Box(.type), Box(Term(.Bound(0)))))))))
+		assert(Value.pi(.Type) { Value.pi(.Type, const($0)) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(0)))))))))
 	}
 
 	func testQuotationMapsQuotedVariablesToBoundVariables() {
@@ -14,7 +14,7 @@ final class ValueTests: XCTestCase {
 	}
 
 	func testQuotationMapsNestedBoundVariablesToBoundVariables() {
-		assert(Value.Pi(Box(.Type)) { _ in Either.right(Value.Pi(Box(.Type), Either.right)) }.quote, ==, Term(.Pi(0, Box(.type), Box(Term(.Pi(1, Box(.type), Box(Term(.Bound(1)))))))))
+		assert(Value.Pi(Box(.Type)) { _ in Either.right(Value.Pi(Box(.Type), Either.right)) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(1)))))))))
 	}
 }
 

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -10,7 +10,7 @@ final class ValueTests: XCTestCase {
 	}
 
 	func testQuotationMapsQuotedVariablesToBoundVariables() {
-		assert(Value.parameter(.Quote(1)).quote, ==, Term(.Bound(1)))
+		assert(Value.free(.Quote(1)).quote, ==, Term(.Bound(1)))
 	}
 
 	func testQuotationMapsNestedBoundVariablesToBoundVariables() {

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -14,7 +14,7 @@ final class ValueTests: XCTestCase {
 	}
 
 	func testQuotationMapsNestedBoundVariablesToBoundVariables() {
-		assert(Value.Pi(Box(.Type)) { _ in Either.right(Value.Pi(Box(.Type), Either.right)) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(1)))))))))
+		assert(Value.pi(.type) { _ in Value.pi(.type, id) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(1)))))))))
 	}
 }
 


### PR DESCRIPTION
- [x] Represent `Boolean` in the language.
- ~~Represent the eliminator as a function.~~ Later.
- ~~Represent `Natural`’s type using Σ?~~ `Natural` isn’t parameterized by anything, so its type is correctly `Type`. Contrast `List` : `Type → Type`—`List` is abstracted over its type argument, so it has a higher type.
- [x] Represent `Natural`s as [Church numerals](http://en.wikipedia.org/wiki/Church_encoding#Church_numerals).
- [x] Reintroduce `Natural` and `Boolean` bindings.
- [x] Fixes #53.
