### PR TITLE
N-ary products

### DIFF
--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -187,5 +187,15 @@ public enum Value: DebugPrintable {
 }
 
 
+private func foldr<S: SequenceType, T>(sequence: S, final: T, combine: (S.Generator.Element, T) -> T) -> T {
+	return foldr(sequence.generate(), final, combine)
+}
+
+private func foldr<G: GeneratorType, T>(var generator: G, final: T, combine: (G.Element, T) -> T) -> T {
+	let next = generator.next()
+	return next.map { combine($0, foldr(generator, final, combine)) } ?? final
+}
+
+
 import Box
 import Prelude

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -26,6 +26,10 @@ public enum Value: DebugPrintable {
 		return .sigma(a, const(b))
 	}
 
+	public static func product(types: [Value]) -> Value {
+		return foldr(types, Value.UnitTerm, Value.product)
+	}
+
 	public static func application(f: Manifold.Neutral, _ v: Value) -> Value {
 		return .neutral(.application(f, v))
 	}

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -21,6 +21,10 @@ final class ValueTests: XCTestCase {
 	func testUnaryProductEndsWithUnitTerm() {
 		assert(Value.product([ Value.type ]).quote, ==, Term(.Sigma(Box(.type), Box(.unitTerm))))
 	}
+
+	func testTernaryProductAssociatesToTheRight() {
+		assert(Value.product([ Value.type, Value.type, Value.type ]).quote, ==, Term(.Sigma(Box(.type), Box(Term(.Sigma(Box(.type), Box(Term(.Sigma(Box(.type), Box(.unitTerm))))))))))
+	}
 }
 
 

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -17,6 +17,10 @@ final class ValueTests: XCTestCase {
 	func testNullaryProductIsUnitTerm() {
 		assert(Value.product([]).quote, ==, Term.unitTerm)
 	}
+
+	func testUnaryProductEndsWithUnitTerm() {
+		assert(Value.product([ Value.type ]).quote, ==, Term(.Sigma(Box(.type), Box(.unitTerm))))
+	}
 }
 
 

--- a/ManifoldTests/ValueTests.swift
+++ b/ManifoldTests/ValueTests.swift
@@ -12,6 +12,11 @@ final class ValueTests: XCTestCase {
 	func testQuotationMapsNestedBoundVariablesToBoundVariables() {
 		assert(Value.pi(.type) { _ in Value.pi(.type, id) }.quote, ==, Term(.Pi(Box(.type), Box(Term(.Pi(Box(.type), Box(Term(.Bound(0)))))))))
 	}
+
+
+	func testNullaryProductIsUnitTerm() {
+		assert(Value.product([]).quote, ==, Term.unitTerm)
+	}
 }
 
 


### PR DESCRIPTION
Adds a constructor `Value.product([ … ])` for n-ary products associating to the right a la Lisp lists, e.g. `(A, (B, (C, ())))`.

Since these are always terminated with the unit term, they’re in some slight conflict with the extant `Value.product(A, B)` constructor which produces `(A, B)`.

It might be preferable at some point to adjust the mapping such that:
- 0-ary products remain `()`
- a unary product of `T` is `T`
- a binary product of `T` and `U` is `(T, U)` like the current binary `Value.product` produces
- higher-ranked products associate to the right without a terminating `()`, e.g. `(A, (B, C))`

This is obviously quite doable, but it’s unclear how useful it would be, and as it’s somewhat distinct from the products used in _The Gentle Art of Levitation_ and related papers, and more engineering effort, I’ve opted to leave things as they are for the time being.
