### PR TITLE
Type value quoting

### DIFF
--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -137,9 +137,8 @@ public struct Term: DebugPrintable, FixpointType, Hashable, Printable {
 			},
 			ifSigma: { t, b -> Either<Error, Value> in
 				t.typecheck(context, from: i)
-					.flatMap { _ in
-						let t = t.evaluate()
-						return b.substitute(0, .free(.Local(i))).typecheck([ .Local(i): t ] + context, from: i + 1)
+					.flatMap { t in
+						b.substitute(0, .free(.Local(i))).typecheck([ .Local(i): t ] + context, from: i + 1)
 							.map { Value.product(t, $0) }
 					}
 			})

--- a/Manifold/Value.swift
+++ b/Manifold/Value.swift
@@ -111,7 +111,7 @@ public enum Value: DebugPrintable {
 		return analysis(
 			ifUnitValue: const(.unitTerm),
 			ifUnitType: const(.unitType),
-			ifType: const(.type),
+			ifType: Term.type,
 			ifPi: { type, f in
 				Term(Checkable.Pi(Box(type.quote(n)), Box(f(.free(.Quote(n))).quote(n + 1))))
 			},

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -19,7 +19,7 @@ final class TermTests: XCTestCase {
 	}
 
 	func testSigmaTypeDescription() {
-		assert(Value.sigma(.type, const(.type)).quote.typecheck().right?.quote.description, ==, "Σ Type . Type")
+		assert(Value.sigma(.type, const(.type)).quote.typecheck().right?.quote.description, ==, "Σ Type1 . Type1")
 	}
 
 	func testTypeOfType0IsType1() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -22,8 +22,8 @@ final class TermTests: XCTestCase {
 		assert(Value.sigma(.type, const(.type)).quote.typecheck().right?.quote.description, ==, "Σ Type . Type")
 	}
 
-	func testTypeOfTypeIsType() {
-		assert(Term.type.typecheck().right?.quote, ==, Term.type)
+	func testTypeOfType0IsType1() {
+		assert(Term.type.typecheck().right?.quote, ==, Term.type(1))
 	}
 
 	func testTypeOfAbstractionIsAbstractionType() {


### PR DESCRIPTION
I noticed that type values were always being quoted to the Type0 term. Whoops!

Looks like we also needed a fix to typechecking sigmas, although I’m a little less certain of that one. It’s “fixed” now but it may still be subtly (or not so subtly) broken and thus care should be taken.
