### PR TITLE
Annotations

### DIFF
--- a/Manifold/Algebra.swift
+++ b/Manifold/Algebra.swift
@@ -8,30 +8,30 @@ public protocol FixpointType {
 }
 
 
-// MARK: Fix: FixpointType over Expression<Fix>
+// MARK: Fix: FixpointType over Inferable<Fix>
 
-public func cata<T, Fix: FixpointType where Fix.Recur == Expression<Fix>>(f: Expression<T> -> T)(_ term: Fix) -> T {
+public func cata<T, Fix: FixpointType where Fix.Recur == Inferable<Fix>>(f: Inferable<T> -> T)(_ term: Fix) -> T {
 	return term |> (out >>> (map <| cata(f)) >>> f)
 }
 
-public func para<T, Fix: FixpointType where Fix.Recur == Expression<Fix>>(f: Expression<(Fix, T)> -> T)(_ term: Fix) -> T {
+public func para<T, Fix: FixpointType where Fix.Recur == Inferable<Fix>>(f: Inferable<(Fix, T)> -> T)(_ term: Fix) -> T {
 	let fanout = { ($0, para(f)($0)) }
 	return term |> (out >>> (map <| fanout) >>> f)
 }
 
 
-public func ana<T, Fix: FixpointType where Fix.Recur == Expression<Fix>>(f: T -> Expression<T>)(_ seed: T) -> Fix {
+public func ana<T, Fix: FixpointType where Fix.Recur == Inferable<Fix>>(f: T -> Inferable<T>)(_ seed: T) -> Fix {
 	return seed |> (Fix.init <<< (map <| ana(f)) <<< f)
 }
 
 
-public func apo<T>(f: T -> Expression<Either<Term, T>>)(_ seed: T) -> Term {
+public func apo<T>(f: T -> Inferable<Either<Term, T>>)(_ seed: T) -> Term {
 	return seed |> (Term.init <<< (map { $0.either(ifLeft: id, ifRight: apo(f)) }) <<< f)
 }
 
 
-private func map<T, U>(f: T -> U)(_ c: Expression<T>) -> Expression<U> {
-	return Expression.map(c)(f)
+private func map<T, U>(f: T -> U)(_ c: Inferable<T>) -> Inferable<U> {
+	return Inferable.map(c)(f)
 }
 
 private func out<Fix: FixpointType>(v: Fix) -> Fix.Recur {

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -32,6 +32,8 @@ public func == <Recur: Equatable> (left: Inferable<Recur>, right: Inferable<Recu
 		return a == b
 	case let (.If(a1, b1, c1), .If(a2, b2, c2)):
 		return a1 == a2 && b1 == b2 && c1 == c2
+	case let (.Annotation(term1, type1), .Annotation(term2, type2)):
+		return term1 == term2 && type1 == type2
 	default:
 		return false
 	}

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -1,5 +1,15 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
+// MARK: Checkable
+
+public func == <Recur: Equatable> (left: Checkable<Recur>, right: Checkable<Recur>) -> Bool {
+	switch (left, right) {
+	case let (.Inferable(a), .Inferable(b)):
+		return a == b
+	}
+}
+
+
 // MARK: Inferable
 
 public func == <Recur: Equatable> (left: Inferable<Recur>, right: Inferable<Recur>) -> Bool {

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -5,7 +5,7 @@
 public func == <Recur: Equatable> (left: Checkable<Recur>, right: Checkable<Recur>) -> Bool {
 	switch (left, right) {
 	case let (.Inferable(a), .Inferable(b)):
-		return a() == b()
+		return a.value == b.value
 	}
 }
 

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -1,8 +1,8 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-// MARK: Expression
+// MARK: Inferable
 
-public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Recur>) -> Bool {
+public func == <Recur: Equatable> (left: Inferable<Recur>, right: Inferable<Recur>) -> Bool {
 	switch (left, right) {
 	case (.Unit, .Unit), (.UnitType, .UnitType), (.BooleanType, .BooleanType):
 		return true

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -5,7 +5,7 @@
 public func == <Recur: Equatable> (left: Checkable<Recur>, right: Checkable<Recur>) -> Bool {
 	switch (left, right) {
 	case let (.Inferable(a), .Inferable(b)):
-		return a == b
+		return a() == b()
 	}
 }
 

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -5,7 +5,7 @@
 public func == <Recur: Equatable> (left: Checkable<Recur>, right: Checkable<Recur>) -> Bool {
 	switch (left, right) {
 	case let (.Inferable(a), .Inferable(b)):
-		return a.value == b.value
+		return a == b
 	}
 }
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -14,7 +14,8 @@ public enum Inferable<Recur> {
 		@noescape ifSigma: (Int, Recur, Recur) -> T,
 		@noescape ifBooleanType: () -> T,
 		@noescape ifBoolean: Bool -> T,
-		@noescape ifIf: (Recur, Recur, Recur) -> T) -> T {
+		@noescape ifIf: (Recur, Recur, Recur) -> T,
+		@noescape ifAnnotation: (Checkable<Recur>, Recur) -> T) -> T {
 		switch self {
 		case .Unit:
 			return ifUnit()
@@ -38,6 +39,8 @@ public enum Inferable<Recur> {
 			return ifBoolean(b)
 		case let .If(a, b, c):
 			return ifIf(a, b, c)
+		case let .Annotation(term, type):
+			return ifAnnotation(term, type)
 		}
 	}
 
@@ -53,6 +56,7 @@ public enum Inferable<Recur> {
 		ifBooleanType: (() -> T)? = nil,
 		ifBoolean: (Bool -> T)? = nil,
 		ifIf: ((Recur, Recur, Recur) -> T)? = nil,
+		ifAnnotation: ((Checkable<Recur>, Recur) -> T)? = nil,
 		@noescape otherwise: () -> T) -> T {
 		return analysis(
 			ifUnit: { ifUnit?() ?? otherwise() },
@@ -65,7 +69,8 @@ public enum Inferable<Recur> {
 			ifSigma: { ifSigma?($0) ?? otherwise() },
 			ifBooleanType: { ifBooleanType?() ?? otherwise() },
 			ifBoolean: { ifBoolean?($0) ?? otherwise() },
-			ifIf: { ifIf?($0) ?? otherwise() })
+			ifIf: { ifIf?($0) ?? otherwise() },
+			ifAnnotation: { ifAnnotation?($0) ?? otherwise() })
 	}
 
 
@@ -83,7 +88,8 @@ public enum Inferable<Recur> {
 			ifSigma: { .Sigma($0, transform($1), transform($2)) },
 			ifBooleanType: const(.BooleanType),
 			ifBoolean: { .Boolean($0) },
-			ifIf: { .If(transform($0), transform($1), transform($2)) })
+			ifIf: { .If(transform($0), transform($1), transform($2)) },
+			ifAnnotation: { .Annotation($0.map(transform), transform($1)) })
 	}
 
 
@@ -100,6 +106,7 @@ public enum Inferable<Recur> {
 	case BooleanType
 	case Boolean(Bool)
 	case If(Recur, Recur, Recur)
+	case Annotation(Checkable<Recur>, Recur)
 }
 
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -9,7 +9,7 @@ public enum Inferable<Recur> {
 		@noescape ifType: Int -> T,
 		@noescape ifVariable: Name -> T,
 		@noescape ifApplication: (Recur, Checkable<Recur>) -> T,
-		@noescape ifLambda: (Int, Recur, Recur) -> T,
+		@noescape ifLambda: (Int, Checkable<Recur>, Checkable<Recur>) -> T,
 		@noescape ifProjection: (Recur, Bool) -> T,
 		@noescape ifSigma: (Int, Recur, Recur) -> T,
 		@noescape ifBooleanType: () -> T,
@@ -50,7 +50,7 @@ public enum Inferable<Recur> {
 		ifType: (Int -> T)? = nil,
 		ifVariable: (Name -> T)? = nil,
 		ifApplication: ((Recur, Checkable<Recur>) -> T)? = nil,
-		ifLambda: ((Int, Recur, Recur) -> T)? = nil,
+		ifLambda: ((Int, Checkable<Recur>, Checkable<Recur>) -> T)? = nil,
 		ifProjection: ((Recur, Bool) -> T)? = nil,
 		ifSigma: ((Int, Recur, Recur) -> T)? = nil,
 		ifBooleanType: (() -> T)? = nil,
@@ -83,7 +83,7 @@ public enum Inferable<Recur> {
 			ifType: { .Type($0) },
 			ifVariable: { .Variable($0) },
 			ifApplication: { .Application(transform($0), $1.map(transform)) },
-			ifLambda: { .Lambda($0, transform($1), transform($2)) },
+			ifLambda: { .Lambda($0, $1.map(transform), $2.map(transform)) },
 			ifProjection: { .Projection(transform($0), $1) },
 			ifSigma: { .Sigma($0, transform($1), transform($2)) },
 			ifBooleanType: const(.BooleanType),
@@ -100,7 +100,7 @@ public enum Inferable<Recur> {
 	case Type(Int)
 	case Variable(Name)
 	case Application(Recur, Checkable<Recur>)
-	case Lambda(Int, Recur, Recur) // (Πx:A)B where B can depend on x
+	case Lambda(Int, Checkable<Recur>, Checkable<Recur>) // (Πx:A)B where B can depend on x
 	case Projection(Recur, Bool)
 	case Sigma(Int, Recur, Recur) // (Σx:A)B where B can depend on x
 	case BooleanType

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -104,14 +104,19 @@ public enum Inferable<Recur> {
 
 
 public enum Checkable<Recur> {
-	case Inferable(Box<Manifold.Inferable<Recur>>)
-
-	public func map<T>(@noescape transform: Recur -> T) -> Checkable<T> {
+	public func analysis<T>(@noescape ifInferable ifInferable: Manifold.Inferable<Recur> -> T) -> T {
 		switch self {
 		case let .Inferable(v):
-			return .Inferable(v.map { $0.map(transform) })
+			return ifInferable(v.value)
 		}
 	}
+
+	public func map<T>(@noescape transform: Recur -> T) -> Checkable<T> {
+		return analysis(ifInferable: { .Inferable(Box($0.map(transform))) })
+	}
+
+	case Inferable(Box<Manifold.Inferable<Recur>>)
+
 }
 
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -104,21 +104,20 @@ public enum Inferable<Recur> {
 
 
 public enum Checkable<Recur> {
-	public func analysis<T>(@noescape ifInferable ifInferable: Manifold.Inferable<Recur> -> T) -> T {
+	public func analysis<T>(@noescape ifInferable ifInferable: Recur -> T) -> T {
 		switch self {
 		case let .Inferable(v):
-			return ifInferable(v.value)
+			return ifInferable(v)
 		}
 	}
 
 	public func map<T>(@noescape transform: Recur -> T) -> Checkable<T> {
-		return analysis(ifInferable: { .Inferable(Box($0.map(transform))) })
+		return analysis(ifInferable: { .Inferable(transform($0)) })
 	}
 
-	case Inferable(Box<Manifold.Inferable<Recur>>)
+	case Inferable(Recur)
 
 }
 
 
-import Box
 import Prelude

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -11,7 +11,7 @@ public enum Inferable<Recur> {
 		@noescape ifApplication: (Recur, Checkable<Recur>) -> T,
 		@noescape ifLambda: (Int, Checkable<Recur>, Checkable<Recur>) -> T,
 		@noescape ifProjection: (Recur, Bool) -> T,
-		@noescape ifSigma: (Int, Recur, Recur) -> T,
+		@noescape ifSigma: (Int, Checkable<Recur>, Checkable<Recur>) -> T,
 		@noescape ifBooleanType: () -> T,
 		@noescape ifBoolean: Bool -> T,
 		@noescape ifIf: (Recur, Recur, Recur) -> T,
@@ -52,7 +52,7 @@ public enum Inferable<Recur> {
 		ifApplication: ((Recur, Checkable<Recur>) -> T)? = nil,
 		ifLambda: ((Int, Checkable<Recur>, Checkable<Recur>) -> T)? = nil,
 		ifProjection: ((Recur, Bool) -> T)? = nil,
-		ifSigma: ((Int, Recur, Recur) -> T)? = nil,
+		ifSigma: ((Int, Checkable<Recur>, Checkable<Recur>) -> T)? = nil,
 		ifBooleanType: (() -> T)? = nil,
 		ifBoolean: (Bool -> T)? = nil,
 		ifIf: ((Recur, Recur, Recur) -> T)? = nil,
@@ -85,7 +85,7 @@ public enum Inferable<Recur> {
 			ifApplication: { .Application(transform($0), $1.map(transform)) },
 			ifLambda: { .Lambda($0, $1.map(transform), $2.map(transform)) },
 			ifProjection: { .Projection(transform($0), $1) },
-			ifSigma: { .Sigma($0, transform($1), transform($2)) },
+			ifSigma: { .Sigma($0, $1.map(transform), $2.map(transform)) },
 			ifBooleanType: const(.BooleanType),
 			ifBoolean: { .Boolean($0) },
 			ifIf: { .If(transform($0), transform($1), transform($2)) },
@@ -102,7 +102,7 @@ public enum Inferable<Recur> {
 	case Application(Recur, Checkable<Recur>)
 	case Lambda(Int, Checkable<Recur>, Checkable<Recur>) // (Πx:A)B where B can depend on x
 	case Projection(Recur, Bool)
-	case Sigma(Int, Recur, Recur) // (Σx:A)B where B can depend on x
+	case Sigma(Int, Checkable<Recur>, Checkable<Recur>) // (Σx:A)B where B can depend on x
 	case BooleanType
 	case Boolean(Bool)
 	case If(Recur, Recur, Recur)

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -103,7 +103,7 @@ public enum Inferable<Recur> {
 }
 
 
-enum Checkable<Recur> {
+public enum Checkable<Recur> {
 	case Inferable(Manifold.Inferable<Recur>)
 }
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -103,4 +103,9 @@ public enum Inferable<Recur> {
 }
 
 
+enum Checkable<Recur> {
+	case Inferable(Manifold.Inferable<Recur>)
+}
+
+
 import Prelude

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -104,8 +104,9 @@ public enum Inferable<Recur> {
 
 
 public enum Checkable<Recur> {
-	case Inferable(() -> Manifold.Inferable<Recur>)
+	case Inferable(Box<Manifold.Inferable<Recur>>)
 }
 
 
+import Box
 import Prelude

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
-public enum Expression<Recur> {
+public enum Inferable<Recur> {
 	// MARK: Analyses
 
 	public func analysis<T>(
@@ -71,7 +71,7 @@ public enum Expression<Recur> {
 
 	// MARK: Functor
 
-	public func map<T>(@noescape transform: Recur -> T) -> Expression<T> {
+	public func map<T>(@noescape transform: Recur -> T) -> Inferable<T> {
 		return analysis(
 			ifUnit: const(.Unit),
 			ifUnitType: const(.UnitType),

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -105,6 +105,13 @@ public enum Inferable<Recur> {
 
 public enum Checkable<Recur> {
 	case Inferable(Box<Manifold.Inferable<Recur>>)
+
+	public func map<T>(@noescape transform: Recur -> T) -> Checkable<T> {
+		switch self {
+		case let .Inferable(v):
+			return .Inferable(v.map { $0.map(transform) })
+		}
+	}
 }
 
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -15,7 +15,7 @@ public enum Inferable<Recur> {
 		@noescape ifBooleanType: () -> T,
 		@noescape ifBoolean: Bool -> T,
 		@noescape ifIf: (Recur, Recur, Recur) -> T,
-		@noescape ifAnnotation: (Checkable<Recur>, Recur) -> T) -> T {
+		@noescape ifAnnotation: (Checkable<Recur>, Checkable<Recur>) -> T) -> T {
 		switch self {
 		case .Unit:
 			return ifUnit()
@@ -56,7 +56,7 @@ public enum Inferable<Recur> {
 		ifBooleanType: (() -> T)? = nil,
 		ifBoolean: (Bool -> T)? = nil,
 		ifIf: ((Recur, Recur, Recur) -> T)? = nil,
-		ifAnnotation: ((Checkable<Recur>, Recur) -> T)? = nil,
+		ifAnnotation: ((Checkable<Recur>, Checkable<Recur>) -> T)? = nil,
 		@noescape otherwise: () -> T) -> T {
 		return analysis(
 			ifUnit: { ifUnit?() ?? otherwise() },
@@ -89,7 +89,7 @@ public enum Inferable<Recur> {
 			ifBooleanType: const(.BooleanType),
 			ifBoolean: { .Boolean($0) },
 			ifIf: { .If(transform($0), transform($1), transform($2)) },
-			ifAnnotation: { .Annotation($0.map(transform), transform($1)) })
+			ifAnnotation: { .Annotation($0.map(transform), $1.map(transform)) })
 	}
 
 
@@ -106,7 +106,7 @@ public enum Inferable<Recur> {
 	case BooleanType
 	case Boolean(Bool)
 	case If(Recur, Recur, Recur)
-	case Annotation(Checkable<Recur>, Recur)
+	case Annotation(Checkable<Recur>, Checkable<Recur>)
 }
 
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -8,7 +8,7 @@ public enum Inferable<Recur> {
 		@noescape ifUnitType: () -> T,
 		@noescape ifType: Int -> T,
 		@noescape ifVariable: Name -> T,
-		@noescape ifApplication: (Recur, Recur) -> T,
+		@noescape ifApplication: (Recur, Checkable<Recur>) -> T,
 		@noescape ifLambda: (Int, Recur, Recur) -> T,
 		@noescape ifProjection: (Recur, Bool) -> T,
 		@noescape ifSigma: (Int, Recur, Recur) -> T,
@@ -49,7 +49,7 @@ public enum Inferable<Recur> {
 		ifUnitType: (() -> T)? = nil,
 		ifType: (Int -> T)? = nil,
 		ifVariable: (Name -> T)? = nil,
-		ifApplication: ((Recur, Recur) -> T)? = nil,
+		ifApplication: ((Recur, Checkable<Recur>) -> T)? = nil,
 		ifLambda: ((Int, Recur, Recur) -> T)? = nil,
 		ifProjection: ((Recur, Bool) -> T)? = nil,
 		ifSigma: ((Int, Recur, Recur) -> T)? = nil,
@@ -82,7 +82,7 @@ public enum Inferable<Recur> {
 			ifUnitType: const(.UnitType),
 			ifType: { .Type($0) },
 			ifVariable: { .Variable($0) },
-			ifApplication: { .Application(transform($0), transform($1)) },
+			ifApplication: { .Application(transform($0), $1.map(transform)) },
 			ifLambda: { .Lambda($0, transform($1), transform($2)) },
 			ifProjection: { .Projection(transform($0), $1) },
 			ifSigma: { .Sigma($0, transform($1), transform($2)) },
@@ -99,7 +99,7 @@ public enum Inferable<Recur> {
 	case UnitType
 	case Type(Int)
 	case Variable(Name)
-	case Application(Recur, Recur)
+	case Application(Recur, Checkable<Recur>)
 	case Lambda(Int, Recur, Recur) // (Πx:A)B where B can depend on x
 	case Projection(Recur, Bool)
 	case Sigma(Int, Recur, Recur) // (Σx:A)B where B can depend on x

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -104,7 +104,7 @@ public enum Inferable<Recur> {
 
 
 public enum Checkable<Recur> {
-	case Inferable(Manifold.Inferable<Recur>)
+	case Inferable(() -> Manifold.Inferable<Recur>)
 }
 
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -133,7 +133,6 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 
 	public var isNormalForm: Bool {
 		return expression.analysis(
-			ifVariable: const(false),
 			ifApplication: const(false),
 			ifProjection: const(false),
 			ifIf: const(false),

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -151,6 +151,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 				ifProjection: { $0.0 },
 				ifSigma: { max($0.0, $0.1) },
 				ifIf: { max($0, $1, $2) },
+				ifAnnotation: { max($0.analysis(ifInferable: id), $1.analysis(ifInferable: id)) },
 				otherwise: const(-1))
 		} (self)
 	}

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -136,6 +136,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 			ifApplication: const(false),
 			ifProjection: const(false),
 			ifIf: const(false),
+			ifAnnotation: const(false),
 			otherwise: const(true))
 	}
 
@@ -226,6 +227,8 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 								: Term.sigma(.booleanType) { Term.`if`($0, then: a, `else`: b) }
 						}
 				}
+		case let .Annotation(term, type):
+			return term.analysis(ifInferable: { $0.typecheck(environment, against: type) })
 		}
 	}
 
@@ -253,6 +256,8 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 			return condition.evaluate(environment).boolean!
 				? then.evaluate(environment)
 				: `else`.evaluate(environment)
+		case let .Annotation(term, _):
+			return term.analysis(ifInferable: { $0.evaluate(environment) })
 		default:
 			return self
 		}
@@ -284,7 +289,8 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 			ifSigma: { "Σ \($0) : \($1) . \($2)" },
 			ifBooleanType: const("Boolean"),
 			ifBoolean: { String(reflecting: $0) },
-			ifIf: { "if \($0) then \($1) else \($2)" })
+			ifIf: { "if \($0) then \($1) else \($2)" },
+			ifAnnotation: { "\($0) : \($1)" })
 	}
 
 
@@ -309,7 +315,8 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 			ifSigma: { 17 ^ $0 ^ $1.hashValue ^ $2.hashValue },
 			ifBooleanType: const(19),
 			ifBoolean: { 23 ^ $0.hashValue },
-			ifIf: { 29 ^ $0.hashValue ^ $1.hashValue ^ $2.hashValue })
+			ifIf: { 29 ^ $0.hashValue ^ $1.hashValue ^ $2.hashValue },
+			ifAnnotation: { 31 ^ $0.analysis(ifInferable: { $0.hashValue }) ^ $1.hashValue })
 	}
 
 
@@ -347,7 +354,8 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 			},
 			ifBooleanType: const("Boolean"),
 			ifBoolean: { String($0) },
-			ifIf: { "if \($0) then \($1) else \($2)" })
+			ifIf: { "if \($0) then \($1) else \($2)" },
+			ifAnnotation: { "\($0) : \($1)" })
 	}
 }
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -216,7 +216,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 				}
 		case let .Lambda(i, t, b):
 			return t.analysis(ifInferable: { t in
-				t.typecheck(environment)
+				t.typecheck(environment, against: Term.type)
 					.flatMap { _ in
 						b.analysis(ifInferable: { b in
 							b.typecheck(environment + [ .Local(i): t ])

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -361,7 +361,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 			ifBooleanType: const("Boolean"),
 			ifBoolean: { String($0) },
 			ifIf: { "if \($0) then \($1) else \($2)" },
-			ifAnnotation: { "\($0) : \($1)" })
+			ifAnnotation: { "\($0.analysis(ifInferable: id)) : \($1.analysis(ifInferable: id))" })
 	}
 }
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -304,19 +304,21 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 	// MARK: Hashable
 
 	public var hashValue: Int {
-		return expression.analysis(
-			ifUnit: const(1),
-			ifUnitType: const(2),
-			ifType: { 3 ^ $0.hashValue },
-			ifVariable: { 5 ^ $0.hashValue },
-			ifApplication: { 7 ^ $0.hashValue ^ $1.hashValue },
-			ifLambda: { 11 ^ $0 ^ $1.hashValue ^ $2.hashValue },
-			ifProjection: { 13 ^ $0.hashValue ^ $1.hashValue },
-			ifSigma: { 17 ^ $0 ^ $1.hashValue ^ $2.hashValue },
-			ifBooleanType: const(19),
-			ifBoolean: { 23 ^ $0.hashValue },
-			ifIf: { 29 ^ $0.hashValue ^ $1.hashValue ^ $2.hashValue },
-			ifAnnotation: { 31 ^ $0.analysis(ifInferable: { $0.hashValue }) ^ $1.hashValue })
+		return cata {
+			$0.analysis(
+				ifUnit: { 1 },
+				ifUnitType: { 2 },
+				ifType: { 3 ^ $0 },
+				ifVariable: { 5 ^ $0.hashValue },
+				ifApplication: { 7 ^ $0 ^ $1 },
+				ifLambda: { 11 ^ $0 ^ $1 ^ $2 },
+				ifProjection: { 13 ^ $0 ^ $1.hashValue },
+				ifSigma: { 17 ^ $0 ^ $1 ^ $2 },
+				ifBooleanType: { 19 },
+				ifBoolean: { 23 ^ $0.hashValue },
+				ifIf: { 29 ^ $0 ^ $1 ^ $2 },
+				ifAnnotation: { 31 ^ $0.analysis(ifInferable: id) ^ $1 })
+		} (self)
 	}
 
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -262,7 +262,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 	public func typecheck(environment: [Name: Term], against: Term) -> Either<Error, Term> {
 		return typecheck(environment)
 			.flatMap { t in
-				(t == against) || (against == .type && t == Term.lambda(.type, const(.type)))
+				(t == against) || (against == .type && t.isType)
 					? Either.right(t)
 					: Either.left("type mismatch: expected (\(String(reflecting: self))) : (\(String(reflecting: against))), actually (\(String(reflecting: self))) : (\(String(reflecting: t))) in environment \(environment)")
 			}

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -1,11 +1,11 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, FixpointType, Hashable, IntegerLiteralConvertible, CustomStringConvertible {
-	public init(_ expression: Expression<Term>) {
+	public init(_ expression: Inferable<Term>) {
 		self.init { expression }
 	}
 
-	public init(_ expression: () -> Expression<Term>) {
+	public init(_ expression: () -> Inferable<Term>) {
 		_expression = expression
 	}
 
@@ -123,8 +123,8 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 		return expression.analysis(ifBoolean: Optional.Some, otherwise: const(nil))
 	}
 
-	private var _expression: () -> Expression<Term>
-	public var expression: Expression<Term> {
+	private var _expression: () -> Inferable<Term>
+	public var expression: Inferable<Term> {
 		return _expression()
 	}
 
@@ -273,7 +273,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 		return cata(Term.toDebugString)(self)
 	}
 
-	private static func toDebugString(expression: Expression<String>) -> String {
+	private static func toDebugString(expression: Inferable<String>) -> String {
 		return expression.analysis(
 			ifUnit: const("()"),
 			ifUnitType: const("Unit"),
@@ -291,7 +291,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 
 	// MARK: FixpointType
 
-	public var out: Expression<Term> {
+	public var out: Inferable<Term> {
 		return expression
 	}
 
@@ -329,7 +329,7 @@ public struct Term: BooleanLiteralConvertible, CustomDebugStringConvertible, Fix
 
 	private static let alphabet = "abcdefghijklmnopqrstuvwxyz"
 
-	private static func toString(expression: Expression<(Term, String)>) -> String {
+	private static func toString(expression: Inferable<(Term, String)>) -> String {
 		let alphabetize: Int -> String = { index in Swift.String(Term.alphabet[advance(Term.alphabet.startIndex, index)]) }
 		return expression.analysis(
 			ifUnit: const("()"),


### PR DESCRIPTION
Separates out checkable and inferable expressions, and adds annotations of checkable expressions. Checkable expressions currently include only the inferable expressions, but that will change when #93 is addressed.
- [x] Allow checkable expressions to occur within lambdas.
- [x] Allow checkable expressions to occur within sigmas.
- [x] Arguably fixes #55.
- [x] Fixes #61.
- [x] Fixes #63.
