### PR TITLE
[CRASH] Demonstrate an illegal instruction crash in swift 2 beta 3

### DIFF
--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D4DF44501B2DB043008DCA5D /* TypecheckingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DF444F1B2DB043008DCA5D /* TypecheckingTests.swift */; };
 		D4E101B81B484606001A7E55 /* NaturalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B71B484606001A7E55 /* NaturalTests.swift */; };
 		D4E101BA1B484611001A7E55 /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B91B484611001A7E55 /* Natural.swift */; };
+		D4E49E611B4B6384002273A3 /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E49E601B4B6384002273A3 /* Description.swift */; };
 		D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */; };
 		D4E829171B521B3400713E60 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E829161B521B3400713E60 /* Module.swift */; };
 		D4E829191B521BFC00713E60 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E829181B521BFC00713E60 /* Binding.swift */; };
@@ -76,6 +77,7 @@
 		D4DF444F1B2DB043008DCA5D /* TypecheckingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypecheckingTests.swift; sourceTree = "<group>"; };
 		D4E101B71B484606001A7E55 /* NaturalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NaturalTests.swift; sourceTree = "<group>"; };
 		D4E101B91B484611001A7E55 /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
+		D4E49E601B4B6384002273A3 /* Description.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Description.swift; sourceTree = "<group>"; };
 		D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLiteralConvertible.swift; sourceTree = "<group>"; };
 		D4E829161B521B3400713E60 /* Module.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Module.swift; sourceTree = "<group>"; };
 		D4E829181B521BFC00713E60 /* Binding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				D415A09A1B51EFDE001C15E5 /* FixpointType+Construction.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4E101B91B484611001A7E55 /* Natural.swift */,
+				D4E49E601B4B6384002273A3 /* Description.swift */,
 				D415A0981B51EA8B001C15E5 /* List.swift */,
 				D4E829161B521B3400713E60 /* Module.swift */,
 				D4E829181B521BFC00713E60 /* Binding.swift */,
@@ -312,6 +315,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D415A09B1B51EFDE001C15E5 /* FixpointType+Construction.swift in Sources */,
+				D4E49E611B4B6384002273A3 /* Description.swift in Sources */,
 				D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */,
 				D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */,
 				D4E8291D1B522A8400713E60 /* LazySequenceType.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D415A09B1B51EFDE001C15E5 /* FixpointType+Construction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D415A09A1B51EFDE001C15E5 /* FixpointType+Construction.swift */; };
 		D4809FBD1AF6BD400084B8FE /* ExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* ExpressionTests.swift */; };
 		D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBE1AF6CD720084B8FE /* Equatable.swift */; };
 		D484903A1B29352600F249F7 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D48490391B29352600F249F7 /* CoreFoundation.framework */; };
@@ -48,6 +49,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D415A09A1B51EFDE001C15E5 /* FixpointType+Construction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FixpointType+Construction.swift"; sourceTree = "<group>"; };
 		D46395AE1B17E24C00AA1B65 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftCheck.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4809FBC1AF6BD400084B8FE /* ExpressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpressionTests.swift; sourceTree = "<group>"; };
 		D4809FBE1AF6CD720084B8FE /* Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Equatable.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 				D4F9F86D1A84977400B7071E /* Error.swift */,
 				D4DE7E721AF66E25004D0CB9 /* Term.swift */,
 				D4B56CB01AFDA26A00D7BD6F /* Expression.swift */,
+				D415A09A1B51EFDE001C15E5 /* FixpointType+Construction.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4E101B91B484611001A7E55 /* Natural.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
@@ -290,6 +293,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D415A09B1B51EFDE001C15E5 /* FixpointType+Construction.swift in Sources */,
 				D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */,
 				D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */,
 				D4E101BA1B484611001A7E55 /* Natural.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		D4DF44501B2DB043008DCA5D /* TypecheckingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4DF444F1B2DB043008DCA5D /* TypecheckingTests.swift */; };
 		D4E101B81B484606001A7E55 /* NaturalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B71B484606001A7E55 /* NaturalTests.swift */; };
 		D4E101BA1B484611001A7E55 /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B91B484611001A7E55 /* Natural.swift */; };
+		D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B84E1B46E2F40065BF22 /* Int.swift */; };
 		D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */; };
@@ -69,6 +70,7 @@
 		D4DF444F1B2DB043008DCA5D /* TypecheckingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypecheckingTests.swift; sourceTree = "<group>"; };
 		D4E101B71B484606001A7E55 /* NaturalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NaturalTests.swift; sourceTree = "<group>"; };
 		D4E101B91B484611001A7E55 /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
+		D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLiteralConvertible.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4F1B84E1B46E2F40065BF22 /* Int.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanSequenceView.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				D4F1B84E1B46E2F40065BF22 /* Int.swift */,
 				D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */,
 				D4F1B8561B470E800065BF22 /* Double.swift */,
+				D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -299,6 +302,7 @@
 				D4E101BA1B484611001A7E55 /* Natural.swift in Sources */,
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
+				D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */,
 				D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */; };
 		D4E829171B521B3400713E60 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E829161B521B3400713E60 /* Module.swift */; };
 		D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */; };
+		D4E8291D1B522A8400713E60 /* LazySequenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291C1B522A8400713E60 /* LazySequenceType.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B84E1B46E2F40065BF22 /* Int.swift */; };
 		D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */; };
@@ -77,6 +78,7 @@
 		D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLiteralConvertible.swift; sourceTree = "<group>"; };
 		D4E829161B521B3400713E60 /* Module.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Module.swift; sourceTree = "<group>"; };
 		D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcatSequenceView.swift; sourceTree = "<group>"; };
+		D4E8291C1B522A8400713E60 /* LazySequenceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazySequenceType.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4F1B84E1B46E2F40065BF22 /* Int.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanSequenceView.swift; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 				D4F1B8561B470E800065BF22 /* Double.swift */,
 				D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */,
 				D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */,
+				D4E8291C1B522A8400713E60 /* LazySequenceType.swift */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -308,6 +311,7 @@
 				D415A09B1B51EFDE001C15E5 /* FixpointType+Construction.swift in Sources */,
 				D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */,
 				D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */,
+				D4E8291D1B522A8400713E60 /* LazySequenceType.swift in Sources */,
 				D4E101BA1B484611001A7E55 /* Natural.swift in Sources */,
 				D415A0991B51EA8B001C15E5 /* List.swift in Sources */,
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D4E101B81B484606001A7E55 /* NaturalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B71B484606001A7E55 /* NaturalTests.swift */; };
 		D4E101BA1B484611001A7E55 /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B91B484611001A7E55 /* Natural.swift */; };
 		D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */; };
+		D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B84E1B46E2F40065BF22 /* Int.swift */; };
 		D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */; };
@@ -73,6 +74,7 @@
 		D4E101B71B484606001A7E55 /* NaturalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NaturalTests.swift; sourceTree = "<group>"; };
 		D4E101B91B484611001A7E55 /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
 		D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLiteralConvertible.swift; sourceTree = "<group>"; };
+		D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcatSequenceView.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4F1B84E1B46E2F40065BF22 /* Int.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanSequenceView.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */,
 				D4F1B8561B470E800065BF22 /* Double.swift */,
 				D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */,
+				D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -310,6 +313,7 @@
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */,
 				D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */,
+				D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */,
 				D4F9F86E1A84977400B7071E /* Error.swift in Sources */,
 				D4F1B8571B470E800065BF22 /* Double.swift in Sources */,
 				D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D4E101B81B484606001A7E55 /* NaturalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B71B484606001A7E55 /* NaturalTests.swift */; };
 		D4E101BA1B484611001A7E55 /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B91B484611001A7E55 /* Natural.swift */; };
 		D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */; };
+		D4E829171B521B3400713E60 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E829161B521B3400713E60 /* Module.swift */; };
 		D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B84E1B46E2F40065BF22 /* Int.swift */; };
@@ -74,6 +75,7 @@
 		D4E101B71B484606001A7E55 /* NaturalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NaturalTests.swift; sourceTree = "<group>"; };
 		D4E101B91B484611001A7E55 /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
 		D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLiteralConvertible.swift; sourceTree = "<group>"; };
+		D4E829161B521B3400713E60 /* Module.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Module.swift; sourceTree = "<group>"; };
 		D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcatSequenceView.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4F1B84E1B46E2F40065BF22 /* Int.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4E101B91B484611001A7E55 /* Natural.swift */,
 				D415A0981B51EA8B001C15E5 /* List.swift */,
+				D4E829161B521B3400713E60 /* Module.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -315,6 +318,7 @@
 				D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */,
 				D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */,
 				D4F9F86E1A84977400B7071E /* Error.swift in Sources */,
+				D4E829171B521B3400713E60 /* Module.swift in Sources */,
 				D4F1B8571B470E800065BF22 /* Double.swift in Sources */,
 				D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */,
 			);

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D415A0991B51EA8B001C15E5 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = D415A0981B51EA8B001C15E5 /* List.swift */; };
 		D415A09B1B51EFDE001C15E5 /* FixpointType+Construction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D415A09A1B51EFDE001C15E5 /* FixpointType+Construction.swift */; };
 		D4809FBD1AF6BD400084B8FE /* ExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* ExpressionTests.swift */; };
 		D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBE1AF6CD720084B8FE /* Equatable.swift */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D415A0981B51EA8B001C15E5 /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		D415A09A1B51EFDE001C15E5 /* FixpointType+Construction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FixpointType+Construction.swift"; sourceTree = "<group>"; };
 		D46395AE1B17E24C00AA1B65 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftCheck.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4809FBC1AF6BD400084B8FE /* ExpressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpressionTests.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				D415A09A1B51EFDE001C15E5 /* FixpointType+Construction.swift */,
 				D4EDEF561AFEDEC5001B9A1D /* Name.swift */,
 				D4E101B91B484611001A7E55 /* Natural.swift */,
+				D415A0981B51EA8B001C15E5 /* List.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -300,6 +303,7 @@
 				D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */,
 				D4809FBF1AF6CD720084B8FE /* Equatable.swift in Sources */,
 				D4E101BA1B484611001A7E55 /* Natural.swift in Sources */,
+				D415A0991B51EA8B001C15E5 /* List.swift in Sources */,
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		D4E101BA1B484611001A7E55 /* Natural.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E101B91B484611001A7E55 /* Natural.swift */; };
 		D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */; };
 		D4E829171B521B3400713E60 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E829161B521B3400713E60 /* Module.swift */; };
+		D4E829191B521BFC00713E60 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E829181B521BFC00713E60 /* Binding.swift */; };
 		D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */; };
 		D4E8291D1B522A8400713E60 /* LazySequenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291C1B522A8400713E60 /* LazySequenceType.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
@@ -77,6 +78,7 @@
 		D4E101B91B484611001A7E55 /* Natural.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Natural.swift; sourceTree = "<group>"; };
 		D4E8289C1B5202BB00713E60 /* StringLiteralConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLiteralConvertible.swift; sourceTree = "<group>"; };
 		D4E829161B521B3400713E60 /* Module.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Module.swift; sourceTree = "<group>"; };
+		D4E829181B521BFC00713E60 /* Binding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcatSequenceView.swift; sourceTree = "<group>"; };
 		D4E8291C1B522A8400713E60 /* LazySequenceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazySequenceType.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				D4E101B91B484611001A7E55 /* Natural.swift */,
 				D415A0981B51EA8B001C15E5 /* List.swift */,
 				D4E829161B521B3400713E60 /* Module.swift */,
+				D4E829181B521BFC00713E60 /* Binding.swift */,
 				D4B3FBEE1A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = Manifold;
@@ -319,6 +322,7 @@
 				D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* Algebra.swift in Sources */,
+				D4E829191B521BFC00713E60 /* Binding.swift in Sources */,
 				D4DE7E731AF66E25004D0CB9 /* Term.swift in Sources */,
 				D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */,
 				D4F9F86E1A84977400B7071E /* Error.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		D4E829191B521BFC00713E60 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E829181B521BFC00713E60 /* Binding.swift */; };
 		D4E8291B1B521F1100713E60 /* ConcatSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */; };
 		D4E8291D1B522A8400713E60 /* LazySequenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291C1B522A8400713E60 /* LazySequenceType.swift */; };
+		D4E8291F1B54285700713E60 /* ListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291E1B54285700713E60 /* ListTests.swift */; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B84E1B46E2F40065BF22 /* Int.swift */; };
 		D4F1B8511B46EBE10065BF22 /* ScanSequenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */; };
@@ -83,6 +84,7 @@
 		D4E829181B521BFC00713E60 /* Binding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		D4E8291A1B521F1100713E60 /* ConcatSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcatSequenceView.swift; sourceTree = "<group>"; };
 		D4E8291C1B522A8400713E60 /* LazySequenceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazySequenceType.swift; sourceTree = "<group>"; };
+		D4E8291E1B54285700713E60 /* ListTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTests.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4F1B84E1B46E2F40065BF22 /* Int.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		D4F1B8501B46EBE10065BF22 /* ScanSequenceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanSequenceView.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				D4E101B71B484606001A7E55 /* NaturalTests.swift */,
 				D4F1B8521B46FD4F0065BF22 /* ScanSequenceViewTests.swift */,
 				D4DF444F1B2DB043008DCA5D /* TypecheckingTests.swift */,
+				D4E8291E1B54285700713E60 /* ListTests.swift */,
 				D4B3FC001A83515800DA2AC3 /* Supporting Files */,
 			);
 			path = ManifoldTests;
@@ -341,6 +344,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4E101B81B484606001A7E55 /* NaturalTests.swift in Sources */,
+				D4E8291F1B54285700713E60 /* ListTests.swift in Sources */,
 				D4F1B8591B470E8E0065BF22 /* DoubleExtensionTests.swift in Sources */,
 				D4809FBD1AF6BD400084B8FE /* ExpressionTests.swift in Sources */,
 				D4DF44501B2DB043008DCA5D /* TypecheckingTests.swift in Sources */,

--- a/Manifold/Algebra.swift
+++ b/Manifold/Algebra.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 public protocol FixpointType: Equatable {
-	init(() -> Expression<Self>)
+	init(_: () -> Expression<Self>)
 	var out: Expression<Self> { get }
 }
 

--- a/Manifold/Algebra.swift
+++ b/Manifold/Algebra.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 public protocol FixpointType: Equatable {
 	init(_: () -> Expression<Self>)

--- a/Manifold/Binding.swift
+++ b/Manifold/Binding.swift
@@ -1,13 +1,13 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 public struct Binding<Recur> {
-	public init(_ symbol: String, _ value: Expression<Recur>, _ type: Expression<Recur>) {
+	public init(_ symbol: Name, _ value: Expression<Recur>, _ type: Expression<Recur>) {
 		self.symbol = symbol
 		self.value = value
 		self.type = type
 	}
 
-	public let symbol: String
+	public let symbol: Name
 	public let value: Expression<Recur>
 	public let type: Expression<Recur>
 }

--- a/Manifold/Binding.swift
+++ b/Manifold/Binding.swift
@@ -1,0 +1,13 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+public struct Binding<Recur> {
+	public init(_ name: String, _ value: Expression<Recur>, _ type: Expression<Recur>) {
+		self.name = name
+		self.value = value
+		self.type = type
+	}
+
+	public let name: String
+	public let value: Expression<Recur>
+	public let type: Expression<Recur>
+}

--- a/Manifold/Binding.swift
+++ b/Manifold/Binding.swift
@@ -1,13 +1,13 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 public struct Binding<Recur> {
-	public init(_ name: String, _ value: Expression<Recur>, _ type: Expression<Recur>) {
-		self.name = name
+	public init(_ symbol: String, _ value: Expression<Recur>, _ type: Expression<Recur>) {
+		self.symbol = symbol
 		self.value = value
 		self.type = type
 	}
 
-	public let name: String
+	public let symbol: String
 	public let value: Expression<Recur>
 	public let type: Expression<Recur>
 }

--- a/Manifold/ConcatSequenceView.swift
+++ b/Manifold/ConcatSequenceView.swift
@@ -1,0 +1,32 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension SequenceType {
+	public func concat<S: SequenceType where S.Generator.Element == Generator.Element>(other: S) -> [Generator.Element] {
+		return Array(lazy(self).concat(other))
+	}
+}
+
+public struct ConcatSequenceView<T>: SequenceType {
+	init<A: SequenceType, B: SequenceType where A.Generator.Element == T, B.Generator.Element == T>(_ a: A, _ b: B) {
+		self.a = AnySequence(a)
+		self.b = AnySequence(b)
+	}
+
+	let a: AnySequence<T>
+	let b: AnySequence<T>
+
+	public func generate() -> AnyGenerator<T> {
+		let a = self.a.generate()
+		let b = self.b.generate()
+
+		return anyGenerator {
+			a.next() ?? b.next()
+		}
+	}
+}
+
+extension LazySequenceType {
+	public func concat<S: SequenceType where S.Generator.Element == Generator.Element>(other: S) -> LazySequence<ConcatSequenceView<Generator.Element>> {
+		return lazy(ConcatSequenceView(self, other))
+	}
+}

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -2,18 +2,18 @@
 
 extension Expression where Recur: FixpointType {
 	public static var description: Module<Recur> {
-		// Tag : λ _ : Enum . Type
-		// Tag = λ E : Enum . λ _ : Boolean . Tag E
+		// Tag : λ _ : Enumeration . Type
+		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
 		let Tag = Binding("Tag",
-			lambda(.Variable("Enum")) { E in Recur.lambda(.BooleanType) { _ in
+			lambda(.Variable("Enumeration")) { E in Recur.lambda(.BooleanType) { _ in
 				.Application(.Variable("Tag"), E)
 			} },
-			lambda(.Variable("Enum"), const(.Type(0))))
+			lambda(.Variable("Enumeration"), const(.Type(0))))
 
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
 			Binding("Label", .Variable("String"), .Type(0)),
-			Binding("Enum", .Application(.Variable("List"), .Variable("Label")), .Type(0)),
+			Binding("Enumeration", .Application(.Variable("List"), .Variable("Label")), .Type(0)),
 
 			Tag,
 		])

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -21,6 +21,12 @@ extension Expression where Recur: FixpointType {
 			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), .Application(.Application(cons, first), rest)) },
 			lambda(label, enumeration) { first, rest in .Application(tag, .Application(.Application(cons, first), rest)) })
 
+		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
+		// there = λ first : Label . (false, rest)
+		let there = Binding("there",
+			lambda(label, enumeration) { first, rest in Recur.lambda(.Application(tag, rest)) { _ in .Annotation(.Product(.Boolean(true), .Unit), .Application(.Application(cons, first), rest)) } },
+			lambda(label, enumeration) { first, rest in .Application(tag, .Application(.Application(cons, first), rest)) })
+
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
 			Binding("Label", .Variable("String"), .Type(0)),
@@ -28,6 +34,7 @@ extension Expression where Recur: FixpointType {
 
 			Tag,
 			here,
+			there,
 		])
 	}
 }

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -11,20 +11,20 @@ extension Expression where Recur: FixpointType {
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
 		let Tag = Binding("Tag",
-			lambda(enumeration, .BooleanType) { E, _ in tag |> E },
+			lambda(enumeration, .BooleanType) { E, _ in tag <| E },
 			lambda(enumeration, const(.Type(0))))
 
 		// here : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// here = λ first : Label . (true, first) : Tag (first :: rest)
 		let here = Binding("here",
-			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), tag |> (cons |> first |> rest)) },
-			lambda(label, enumeration) { first, rest in tag |> (cons |> first |> rest) })
+			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), tag <| (cons <| first <| rest)) },
+			lambda(label, enumeration) { first, rest in tag <| (cons <| first <| rest) })
 
 		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// there = λ first : Label . (false, rest) : Tag (first :: rest)
 		let there = Binding("there",
-			lambda(label, enumeration) { first, rest in Recur.lambda(tag |> rest) { next in .Annotation(.Product(.Boolean(true), next), tag |> (cons |> first |> rest)) } },
-			lambda(label, enumeration) { first, rest in tag |> (cons |> first |> rest) })
+			lambda(label, enumeration) { first, rest in Recur.lambda(tag <| rest) { next in .Annotation(.Product(.Boolean(true), next), tag <| (cons <| first <| rest)) } },
+			lambda(label, enumeration) { first, rest in tag <| (cons <| first <| rest) })
 
 
 		// Branches : λ E : Enumeration . λ _ : (λ _ : Tag E . Type) . Type
@@ -33,24 +33,24 @@ extension Expression where Recur: FixpointType {
 		//     else Unit
 		let Branches = Binding("Branches",
 			lambda(enumeration) { E in
-				Recur.lambda(.lambda(tag |> E, const(.Type))) { P in
+				Recur.lambda(.lambda(tag <| E, const(.Type))) { P in
 					.If(.Projection(E, false),
 						.Product(
-							P |> Recur("here"),
-							branches |> E |> Recur.lambda(tag |> E) { t in
-								P |> (Recur("there") |> t)
+							P <| Recur("here"),
+							branches <| E <| Recur.lambda(tag <| E) { t in
+								P <| (Recur("there") <| t)
 							}),
 						.Unit)
 				}
 			},
 			lambda(enumeration) { E in
-				.lambda(.lambda(tag |> E, const(.Type)), const(.Type))
+				.lambda(.lambda(tag <| E, const(.Type)), const(.Type))
 			})
 
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
 			Binding("Label", "String", .Type(0)),
-			Binding("Enumeration", (Recur("List") |> label).out, .Type(0)),
+			Binding("Enumeration", (Recur("List") <| label).out, .Type(0)),
 
 			Tag,
 			here,

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -2,7 +2,7 @@
 
 extension Expression where Recur: FixpointType {
 	public static var description: Module<Recur> {
-		let tag = Recur("Tag")
+		let Tag = Recur("Tag")
 		let enumeration = Recur("Enumeration")
 		let label = Recur("Label")
 		let cons = Recur("::")
@@ -10,21 +10,21 @@ extension Expression where Recur: FixpointType {
 
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
-		let Tag = Binding("Tag",
-			lambda(enumeration, .BooleanType) { E, _ in tag[E] },
+		let tag = Binding("Tag",
+			lambda(enumeration, .BooleanType) { E, _ in Tag[E] },
 			lambda(enumeration, const(.Type(0))))
 
 		// here : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// here = λ first : Label . (true, first) : Tag (first :: rest)
 		let here = Binding("here",
-			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), tag[cons[first, rest]]) },
-			lambda(label, enumeration) { first, rest in tag[cons[first, rest]] })
+			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), Tag[cons[first, rest]]) },
+			lambda(label, enumeration) { first, rest in Tag[cons[first, rest]] })
 
 		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// there = λ first : Label . (false, rest) : Tag (first :: rest)
 		let there = Binding("there",
-			lambda(label, enumeration) { first, rest in Recur.lambda(tag[rest]) { next in .Annotation(.Product(.Boolean(true), next), tag[cons[first, rest]]) } },
-			lambda(label, enumeration) { first, rest in tag[cons[first, rest]] })
+			lambda(label, enumeration) { first, rest in Recur.lambda(Tag[rest]) { next in .Annotation(.Product(.Boolean(true), next), Tag[cons[first, rest]]) } },
+			lambda(label, enumeration) { first, rest in Tag[cons[first, rest]] })
 
 
 		// Branches : λ E : Enumeration . λ _ : (λ _ : Tag E . Type) . Type
@@ -33,18 +33,18 @@ extension Expression where Recur: FixpointType {
 		//     else Unit
 		let Branches = Binding("Branches",
 			lambda(enumeration) { E in
-				Recur.lambda(.lambda(tag[E], const(.Type))) { P in
+				Recur.lambda(.lambda(Tag[E], const(.Type))) { P in
 					.If(.Projection(E, false),
 						.Product(
 							P[Recur("here")],
-							branches[E, Recur.lambda(tag[E]) { t in
+							branches[E, Recur.lambda(Tag[E]) { t in
 								P[Recur("there")[t]]
 							}]),
 						.Unit)
 				}
 			},
 			lambda(enumeration) { E in
-				.lambda(.lambda(tag[E], const(.Type)), const(.Type))
+				.lambda(.lambda(Tag[E], const(.Type)), const(.Type))
 			})
 
 		// case : λ E : Enumeration . λ P : (λ _ : Tag E . Type) . λ cs : Branches E P . λ t : Tag E . P t
@@ -53,17 +53,17 @@ extension Expression where Recur: FixpointType {
 		//     else cs.0
 		let `case` = Binding("case",
 			lambda(enumeration) { E in
-				Recur.lambda(Recur.lambda(tag[E], const(.Type))) { P in
-					Recur.lambda(branches[E, P]) { cs in Recur.lambda(tag[E]) { t in
+				Recur.lambda(Recur.lambda(Tag[E], const(.Type))) { P in
+					Recur.lambda(branches[E, P]) { cs in Recur.lambda(Tag[E]) { t in
 						.If(.Projection(t, false),
-							Recur("case")[E, Recur.lambda(tag[E]) { t in P[Recur("there")[t]] }, .Projection(cs, true), t],
+							Recur("case")[E, Recur.lambda(Tag[E]) { t in P[Recur("there")[t]] }, .Projection(cs, true), t],
 							.Projection(cs, false))
 					} }
 				}
 			},
 			lambda(enumeration) { E in
-				Recur.lambda(.lambda(tag[E], const(.Type))) { P in
-					.lambda(branches[E, P], const(Recur.lambda(tag[E]) { t in P[t] }))
+				Recur.lambda(.lambda(Tag[E], const(.Type))) { P in
+					.lambda(branches[E, P], const(Recur.lambda(Tag[E]) { t in P[t] }))
 				}
 			})
 
@@ -72,7 +72,7 @@ extension Expression where Recur: FixpointType {
 			Binding("Label", "String", .Type(0)),
 			Binding("Enumeration", Recur("List")[label].out, .Type(0)),
 
-			Tag,
+			tag,
 			here,
 			there,
 

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -28,7 +28,7 @@ extension Expression where Recur: FixpointType {
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
 			Binding("Label", .Variable("String"), .Type(0)),
-			Binding("Enumeration", .Application(.Variable("List"), .Variable("Label")), .Type(0)),
+			Binding("Enumeration", .Application(.Variable("List"), label), .Type(0)),
 
 			Tag,
 			here,

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -2,10 +2,10 @@
 
 extension Expression where Recur: FixpointType {
 	public static var description: Module<Recur> {
-		let tag = Recur.Variable("Tag")
-		let enumeration = Recur.Variable("Enumeration")
-		let label = Recur.Variable("Label")
-		let cons = Recur.Variable("::")
+		let tag = Recur("Tag")
+		let enumeration = Recur("Enumeration")
+		let label = Recur("Label")
+		let cons = Recur("::")
 
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
@@ -27,7 +27,7 @@ extension Expression where Recur: FixpointType {
 
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
-			Binding("Label", .Variable("String"), .Type(0)),
+			Binding("Label", "String", .Type(0)),
 			Binding("Enumeration", .Application(.Variable("List"), label), .Type(0)),
 
 			Tag,

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -12,9 +12,7 @@ extension Expression where Recur: FixpointType {
 
 
 		let Tag = Binding("Tag",
-			lambda(enumeration, .BooleanType) { E, _ in
-				.Application(tag, E)
-			},
+			lambda(enumeration, .BooleanType) { E, _ in .Application(tag, E) },
 			lambda(enumeration, const(.Type(0))))
 
 		return Module([ list ], [

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -15,12 +15,19 @@ extension Expression where Recur: FixpointType {
 			lambda(enumeration, .BooleanType) { E, _ in .Application(tag, E) },
 			lambda(enumeration, const(.Type(0))))
 
+		// here : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
+		// here = λ first : Label . (true, first)
+		let here = Binding("here",
+			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), .Application(.Application(cons, first), rest)) },
+			lambda(label, enumeration) { first, rest in .Application(tag, .Application(.Application(cons, first), rest)) })
+
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
 			Binding("Label", .Variable("String"), .Type(0)),
 			Binding("Enumeration", .Application(.Variable("List"), .Variable("Label")), .Type(0)),
 
 			Tag,
+			here,
 		])
 	}
 }

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -1,0 +1,24 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension Expression where Recur: FixpointType {
+	public static var description: Module<Recur> {
+		// Tag : λ _ : Enum . Type
+		// Tag = λ E : Enum . λ _ : Boolean . Tag E
+		let Tag = Binding("Tag",
+			lambda(.Variable("Enum")) { E in Recur.lambda(.BooleanType) { _ in
+				.Application(.Variable("Tag"), E)
+			} },
+			lambda(.Variable("Enum"), const(.Type(0))))
+
+		return Module([ list ], [
+			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
+			Binding("Label", .Variable("String"), .Type(0)),
+			Binding("Enum", .Application(.Variable("List"), .Variable("Label")), .Type(0)),
+
+			Tag,
+		])
+	}
+}
+
+
+import Prelude

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -4,6 +4,13 @@ extension Expression where Recur: FixpointType {
 	public static var description: Module<Recur> {
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
+
+		let tag = Recur.Variable("Tag")
+		let enumeration = Recur.Variable("Enumeration")
+		let label = Recur.Variable("Label")
+		let cons = Recur.Variable("::")
+
+
 		let Tag = Binding("Tag",
 			lambda(.Variable("Enumeration")) { E in Recur.lambda(.BooleanType) { _ in
 				.Application(.Variable("Tag"), E)

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -11,20 +11,20 @@ extension Expression where Recur: FixpointType {
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
 		let Tag = Binding("Tag",
-			lambda(enumeration, .BooleanType) { E, _ in tag <| E },
+			lambda(enumeration, .BooleanType) { E, _ in tag[E] },
 			lambda(enumeration, const(.Type(0))))
 
 		// here : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// here = λ first : Label . (true, first) : Tag (first :: rest)
 		let here = Binding("here",
-			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), tag <| (cons <| first <| rest)) },
-			lambda(label, enumeration) { first, rest in tag <| (cons <| first <| rest) })
+			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), tag[cons[first, rest]]) },
+			lambda(label, enumeration) { first, rest in tag[cons[first, rest]] })
 
 		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// there = λ first : Label . (false, rest) : Tag (first :: rest)
 		let there = Binding("there",
-			lambda(label, enumeration) { first, rest in Recur.lambda(tag <| rest) { next in .Annotation(.Product(.Boolean(true), next), tag <| (cons <| first <| rest)) } },
-			lambda(label, enumeration) { first, rest in tag <| (cons <| first <| rest) })
+			lambda(label, enumeration) { first, rest in Recur.lambda(tag[rest]) { next in .Annotation(.Product(.Boolean(true), next), tag[cons[first, rest]]) } },
+			lambda(label, enumeration) { first, rest in tag[cons[first, rest]] })
 
 
 		// Branches : λ E : Enumeration . λ _ : (λ _ : Tag E . Type) . Type
@@ -33,18 +33,18 @@ extension Expression where Recur: FixpointType {
 		//     else Unit
 		let Branches = Binding("Branches",
 			lambda(enumeration) { E in
-				Recur.lambda(.lambda(tag <| E, const(.Type))) { P in
+				Recur.lambda(.lambda(tag[E], const(.Type))) { P in
 					.If(.Projection(E, false),
 						.Product(
-							P <| Recur("here"),
-							branches <| E <| Recur.lambda(tag <| E) { t in
-								P <| (Recur("there") <| t)
-							}),
+							P[Recur("here")],
+							branches[E, Recur.lambda(tag[E]) { t in
+								P[Recur("there")[t]]
+							}]),
 						.Unit)
 				}
 			},
 			lambda(enumeration) { E in
-				.lambda(.lambda(tag <| E, const(.Type)), const(.Type))
+				.lambda(.lambda(tag[E], const(.Type)), const(.Type))
 			})
 
 		// case : λ E : Enumeration . λ P : (λ _ : Tag E . Type) . λ cs : Branches E P . λ t : Tag E . P t
@@ -53,24 +53,24 @@ extension Expression where Recur: FixpointType {
 		//     else cs.0
 		let `case` = Binding("case",
 			lambda(enumeration) { E in
-				Recur.lambda(Recur.lambda(tag <| E, const(.Type))) { P in
-					Recur.lambda(branches <| E <| P) { cs in Recur.lambda(tag <| E) { t in
+				Recur.lambda(Recur.lambda(tag[E], const(.Type))) { P in
+					Recur.lambda(branches[E, P]) { cs in Recur.lambda(tag[E]) { t in
 						.If(.Projection(t, false),
-							Recur("case") <| E <| Recur.lambda(tag <| E) { t in P <| (Recur("there") <| t) } <| .Projection(cs, true) <| t,
+							Recur("case")[E, Recur.lambda(tag[E]) { t in P[Recur("there")[t]] }, .Projection(cs, true), t],
 							.Projection(cs, false))
 					} }
 				}
 			},
 			lambda(enumeration) { E in
-				Recur.lambda(.lambda(tag <| E, const(.Type))) { P in
-					.lambda(branches <| E <| P, const(Recur.lambda(tag <| E) { t in P <| t }))
+				Recur.lambda(.lambda(tag[E], const(.Type))) { P in
+					.lambda(branches[E, P], const(Recur.lambda(tag[E]) { t in P[t] }))
 				}
 			})
 
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
 			Binding("Label", "String", .Type(0)),
-			Binding("Enumeration", (Recur("List") <| label).out, .Type(0)),
+			Binding("Enumeration", Recur("List")[label].out, .Type(0)),
 
 			Tag,
 			here,

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -11,20 +11,20 @@ extension Expression where Recur: FixpointType {
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
 		let Tag = Binding("Tag",
-			lambda(enumeration, .BooleanType) { E, _ in .Application(tag, E) },
+			lambda(enumeration, .BooleanType) { E, _ in tag |> E },
 			lambda(enumeration, const(.Type(0))))
 
 		// here : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// here = λ first : Label . (true, first)
 		let here = Binding("here",
-			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), .Application(.Application(cons, first), rest)) },
-			lambda(label, enumeration) { first, rest in .Application(tag, .Application(.Application(cons, first), rest)) })
+			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), tag |> (cons |> first |> rest)) },
+			lambda(label, enumeration) { first, rest in tag |> (cons |> first |> rest) })
 
 		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// there = λ first : Label . (false, rest)
 		let there = Binding("there",
-			lambda(label, enumeration) { first, rest in Recur.lambda(.Application(tag, rest)) { next in .Annotation(.Product(.Boolean(true), next), .Application(.Application(cons, first), rest)) } },
-			lambda(label, enumeration) { first, rest in .Application(tag, .Application(.Application(cons, first), rest)) })
+			lambda(label, enumeration) { first, rest in Recur.lambda(tag |> rest) { next in .Annotation(.Product(.Boolean(true), next), tag |> (cons |> first |> rest)) } },
+			lambda(label, enumeration) { first, rest in tag |> (cons |> first |> rest) })
 
 
 		// Branches : λ E : Enumeration . λ _ : (λ _ : Tag E . Type) . Type
@@ -33,24 +33,24 @@ extension Expression where Recur: FixpointType {
 		//     else Unit
 		let Branches = Binding("Branches",
 			lambda(enumeration) { E in
-				Recur.lambda(.lambda(.Application(tag, E), const(.Type))) { P in
+				Recur.lambda(.lambda(tag |> E, const(.Type))) { P in
 					.If(.Projection(E, false),
 						.Product(
-							.Application(P, Recur("here")),
-							.Application(.Application(branches, E), Recur.lambda(.Application(tag, E)) { t in
-								.Application(P, .Application(Recur("there"), t))
-							})),
+							P |> Recur("here"),
+							branches |> E |> Recur.lambda(tag |> E) { t in
+								P |> (Recur("there") |> t)
+							}),
 						.Unit)
 				}
 			},
 			lambda(enumeration) { E in
-				.lambda(.lambda(.Application(tag, E), const(.Type)), const(.Type))
+				.lambda(.lambda(tag |> E, const(.Type)), const(.Type))
 			})
 
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
 			Binding("Label", "String", .Type(0)),
-			Binding("Enumeration", .Application(.Variable("List"), label), .Type(0)),
+			Binding("Enumeration", (Recur("List") |> label).out, .Type(0)),
 
 			Tag,
 			here,

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -15,13 +15,13 @@ extension Expression where Recur: FixpointType {
 			lambda(enumeration, const(.Type(0))))
 
 		// here : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
-		// here = λ first : Label . (true, first)
+		// here = λ first : Label . (true, first) : Tag (first :: rest)
 		let here = Binding("here",
 			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), tag |> (cons |> first |> rest)) },
 			lambda(label, enumeration) { first, rest in tag |> (cons |> first |> rest) })
 
 		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
-		// there = λ first : Label . (false, rest)
+		// there = λ first : Label . (false, rest) : Tag (first :: rest)
 		let there = Binding("there",
 			lambda(label, enumeration) { first, rest in Recur.lambda(tag |> rest) { next in .Annotation(.Product(.Boolean(true), next), tag |> (cons |> first |> rest)) } },
 			lambda(label, enumeration) { first, rest in tag |> (cons |> first |> rest) })

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -2,15 +2,13 @@
 
 extension Expression where Recur: FixpointType {
 	public static var description: Module<Recur> {
-		// Tag : λ _ : Enumeration . Type
-		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
-
 		let tag = Recur.Variable("Tag")
 		let enumeration = Recur.Variable("Enumeration")
 		let label = Recur.Variable("Label")
 		let cons = Recur.Variable("::")
 
-
+		// Tag : λ _ : Enumeration . Type
+		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
 		let Tag = Binding("Tag",
 			lambda(enumeration, .BooleanType) { E, _ in .Application(tag, E) },
 			lambda(enumeration, const(.Type(0))))

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -6,7 +6,7 @@ extension Expression where Recur: FixpointType {
 		let enumeration = Recur("Enumeration")
 		let label = Recur("Label")
 		let cons = Recur("::")
-		let branches = Recur("Branches")
+		let Branches = Recur("Branches")
 
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
@@ -31,13 +31,13 @@ extension Expression where Recur: FixpointType {
 		// Branches = λ E : Enumeration . λ P : (λ _ : Tag E . Type) . if E.0
 		//     then (P here, Branches E (λ t : Tag E . P (there t)))
 		//     else Unit
-		let Branches = Binding("Branches",
+		let branches = Binding("Branches",
 			lambda(enumeration) { E in
 				Recur.lambda(.lambda(Tag[E], const(.Type))) { P in
 					.If(.Projection(E, false),
 						.Product(
 							P[Recur("here")],
-							branches[E, Recur.lambda(Tag[E]) { t in
+							Branches[E, Recur.lambda(Tag[E]) { t in
 								P[Recur("there")[t]]
 							}]),
 						.Unit)
@@ -54,7 +54,7 @@ extension Expression where Recur: FixpointType {
 		let `case` = Binding("case",
 			lambda(enumeration) { E in
 				Recur.lambda(Recur.lambda(Tag[E], const(.Type))) { P in
-					Recur.lambda(branches[E, P]) { cs in Recur.lambda(Tag[E]) { t in
+					Recur.lambda(Branches[E, P]) { cs in Recur.lambda(Tag[E]) { t in
 						.If(.Projection(t, false),
 							Recur("case")[E, Recur.lambda(Tag[E]) { t in P[Recur("there")[t]] }, .Projection(cs, true), t],
 							.Projection(cs, false))
@@ -63,7 +63,7 @@ extension Expression where Recur: FixpointType {
 			},
 			lambda(enumeration) { E in
 				Recur.lambda(.lambda(Tag[E], const(.Type))) { P in
-					.lambda(branches[E, P], const(Recur.lambda(Tag[E]) { t in P[t] }))
+					.lambda(Branches[E, P], const(Recur.lambda(Tag[E]) { t in P[t] }))
 				}
 			})
 
@@ -76,7 +76,7 @@ extension Expression where Recur: FixpointType {
 			here,
 			there,
 
-			Branches,
+			branches,
 			`case`,
 		])
 	}

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -12,10 +12,10 @@ extension Expression where Recur: FixpointType {
 
 
 		let Tag = Binding("Tag",
-			lambda(.Variable("Enumeration")) { E in Recur.lambda(.BooleanType) { _ in
-				.Application(.Variable("Tag"), E)
-			} },
-			lambda(.Variable("Enumeration"), const(.Type(0))))
+			lambda(enumeration, .BooleanType) { E, _ in
+				.Application(tag, E)
+			},
+			lambda(enumeration, const(.Type(0))))
 
 		return Module([ list ], [
 			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -34,7 +34,7 @@ extension Expression where Recur: FixpointType {
 		let branches = Binding("Branches",
 			lambda(enumeration) { E in
 				Recur.lambda(.lambda(Tag[E], const(.Type))) { P in
-					.If(.Projection(E, false),
+					.If(E.first,
 						.Product(
 							P[Recur("here")],
 							Branches[E, Recur.lambda(Tag[E]) { t in
@@ -55,9 +55,9 @@ extension Expression where Recur: FixpointType {
 			lambda(enumeration) { E in
 				Recur.lambda(Recur.lambda(Tag[E], const(.Type))) { P in
 					Recur.lambda(Branches[E, P]) { cs in Recur.lambda(Tag[E]) { t in
-						.If(.Projection(t, false),
-							Recur("case")[E, Recur.lambda(Tag[E]) { t in P[Recur("there")[t]] }, .Projection(cs, true), t],
-							.Projection(cs, false))
+						.If(t.first,
+							Recur("case")[E, Recur.lambda(Tag[E]) { t in P[Recur("there")[t]] }, cs.second, t],
+							cs.first)
 					} }
 				}
 			},

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -3,28 +3,28 @@
 extension Expression where Recur: FixpointType {
 	public static var description: Module<Recur> {
 		let Tag = Recur("Tag")
-		let enumeration = Recur("Enumeration")
-		let label = Recur("Label")
+		let Enumeration = Recur("Enumeration")
+		let Label = Recur("Label")
 		let cons = Recur("::")
 		let Branches = Recur("Branches")
 
 		// Tag : λ _ : Enumeration . Type
 		// Tag = λ E : Enumeration . λ _ : Boolean . Tag E
 		let tag = Binding("Tag",
-			lambda(enumeration, .BooleanType) { E, _ in Tag[E] },
-			lambda(enumeration, const(.Type(0))))
+			lambda(Enumeration, .BooleanType) { E, _ in Tag[E] },
+			lambda(Enumeration, const(.Type(0))))
 
 		// here : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// here = λ first : Label . (true, first) : Tag (first :: rest)
 		let here = Binding("here",
-			lambda(label, enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), Tag[cons[first, rest]]) },
-			lambda(label, enumeration) { first, rest in Tag[cons[first, rest]] })
+			lambda(Label, Enumeration) { first, rest in .Annotation(.Product(.Boolean(false), .Unit), Tag[cons[first, rest]]) },
+			lambda(Label, Enumeration) { first, rest in Tag[cons[first, rest]] })
 
 		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// there = λ first : Label . (false, rest) : Tag (first :: rest)
 		let there = Binding("there",
-			lambda(label, enumeration) { first, rest in Recur.lambda(Tag[rest]) { next in .Annotation(.Product(.Boolean(true), next), Tag[cons[first, rest]]) } },
-			lambda(label, enumeration) { first, rest in Tag[cons[first, rest]] })
+			lambda(Label, Enumeration) { first, rest in Recur.lambda(Tag[rest]) { next in .Annotation(.Product(.Boolean(true), next), Tag[cons[first, rest]]) } },
+			lambda(Label, Enumeration) { first, rest in Tag[cons[first, rest]] })
 
 
 		// Branches : λ E : Enumeration . λ _ : (λ _ : Tag E . Type) . Type
@@ -32,7 +32,7 @@ extension Expression where Recur: FixpointType {
 		//     then (P here, Branches E (λ t : Tag E . P (there t)))
 		//     else Unit
 		let branches = Binding("Branches",
-			lambda(enumeration) { E in
+			lambda(Enumeration) { E in
 				Recur.lambda(.lambda(Tag[E], const(.Type))) { P in
 					.If(E.first,
 						.Product(
@@ -43,7 +43,7 @@ extension Expression where Recur: FixpointType {
 						.Unit)
 				}
 			},
-			lambda(enumeration) { E in
+			lambda(Enumeration) { E in
 				.lambda(.lambda(Tag[E], const(.Type)), const(.Type))
 			})
 
@@ -52,7 +52,7 @@ extension Expression where Recur: FixpointType {
 		//     then case E (λ t : Tag E . P (there t)) cs.1 t
 		//     else cs.0
 		let `case` = Binding("case",
-			lambda(enumeration) { E in
+			lambda(Enumeration) { E in
 				Recur.lambda(Recur.lambda(Tag[E], const(.Type))) { P in
 					Recur.lambda(Branches[E, P]) { cs in Recur.lambda(Tag[E]) { t in
 						.If(t.first,
@@ -61,16 +61,16 @@ extension Expression where Recur: FixpointType {
 					} }
 				}
 			},
-			lambda(enumeration) { E in
+			lambda(Enumeration) { E in
 				Recur.lambda(.lambda(Tag[E], const(.Type))) { P in
 					.lambda(Branches[E, P], const(Recur.lambda(Tag[E]) { t in P[t] }))
 				}
 			})
 
 		return Module([ list ], [
-			Binding("String", .Axiom(String.self, .Type(0)), .Type(0)),
+			Binding("String", Axiom(String.self, .Type), .Type(0)),
 			Binding("Label", "String", .Type(0)),
-			Binding("Enumeration", Recur("List")[label].out, .Type(0)),
+			Binding("Enumeration", Recur("List")[Label].out, .Type(0)),
 
 			tag,
 			here,

--- a/Manifold/Description.swift
+++ b/Manifold/Description.swift
@@ -22,7 +22,7 @@ extension Expression where Recur: FixpointType {
 		// there : λ first : Label . λ rest : Enumeration . Tag (first :: rest)
 		// there = λ first : Label . (false, rest)
 		let there = Binding("there",
-			lambda(label, enumeration) { first, rest in Recur.lambda(.Application(tag, rest)) { _ in .Annotation(.Product(.Boolean(true), .Unit), .Application(.Application(cons, first), rest)) } },
+			lambda(label, enumeration) { first, rest in Recur.lambda(.Application(tag, rest)) { next in .Annotation(.Product(.Boolean(true), next), .Application(.Application(cons, first), rest)) } },
 			lambda(label, enumeration) { first, rest in .Application(tag, .Application(.Application(cons, first), rest)) })
 
 		return Module([ list ], [

--- a/Manifold/Dictionary.swift
+++ b/Manifold/Dictionary.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Dictionary {
 	internal init<S: SequenceType where S.Generator.Element == Element>(_ elements: S) {

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -24,6 +24,8 @@ public func == <Recur: Equatable> (left: Expression<Recur>, right: Expression<Re
 		return a1 == a2 && b1 == b2 && c1 == c2
 	case let (.Annotation(term1, type1), .Annotation(term2, type2)):
 		return term1 == term2 && type1 == type2
+	case let (.Axiom(_, type1), .Axiom(_, type2)):
+		return type1 == type2
 	default:
 		return false
 	}

--- a/Manifold/Equatable.swift
+++ b/Manifold/Equatable.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 // MARK: Expression
 

--- a/Manifold/Error.swift
+++ b/Manifold/Error.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 public enum Error: Equatable, CustomStringConvertible, StringInterpolationConvertible, StringLiteralConvertible {
 	public init(reason: String) {

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -98,7 +98,6 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 	public typealias Definition = (symbol: Name, value: Expression, type: Expression)
 	public typealias Environment = [Name: Expression]
 	public typealias Context = [Name: Expression]
-	public typealias Space = (environment: Environment, context: Context)
 
 
 	// MARK: BooleanLiteralConvertible

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -1,6 +1,6 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
-public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertible, IntegerLiteralConvertible {
+public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertible, IntegerLiteralConvertible, StringLiteralConvertible {
 	// MARK: Analyses
 
 	public func analysis<T>(
@@ -163,6 +163,13 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 
 	public init(integerLiteral value: Int) {
 		self = .Variable(.Local(value))
+	}
+
+
+	// MARK: StringLiteralConvertible
+
+	public init(stringLiteral: String) {
+		self = .Variable(.Global(stringLiteral))
 	}
 
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -96,7 +96,7 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 	// MARK: Environment/context construction
 
 	/// Construct an environment and context from symbol/value/type triples.
-	public static func environmentAndContext<S: SequenceType where S.Generator.Element == (Name, Expression, Expression)>(sequence: S) -> ([Name: Expression], [Name: Expression]) {
+	public static func environmentAndContext<S: SequenceType where S.Generator.Element == (Name, Expression, Expression)>(sequence: S) -> (environment: [Name: Expression], context: [Name: Expression]) {
 		return sequence.reduce(([Name: Expression](), [Name: Expression]())) { into, each in
 			(into.0 + [each.0: each.1], into.1 + [each.0: each.2])
 		}

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -210,6 +210,18 @@ extension Expression where Recur: FixpointType {
 		return .Lambda(n, type, body)
 	}
 
+	public static func lambda(type1: Recur, _ type2: Recur, _ f: (Recur, Recur) -> Recur) -> Expression {
+		return lambda(type1) { a in Recur.lambda(type2) { b in f(a, b) } }
+	}
+
+	public static func lambda(type1: Recur, _ type2: Recur, _ type3: Recur, _ f: (Recur, Recur, Recur) -> Recur) -> Expression {
+		return lambda(type1) { a in Recur.lambda(type2) { b in Recur.lambda(type3) { c in f(a, b, c) } } }
+	}
+
+	public static func lambda(type1: Recur, _ type2: Recur, _ type3: Recur, _ type4: Recur, _ f: (Recur, Recur, Recur, Recur) -> Recur) -> Expression {
+		return lambda(type1) { a in Recur.lambda(type2) { b in Recur.lambda(type3) { c in Recur.lambda(type4) { d in f(a, b, c, d) } } } }
+	}
+
 
 	// MARK: Destructuring accessors
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -249,7 +249,7 @@ extension Expression where Recur: FixpointType {
 
 	// MARK: Evaluation
 
-	public func evaluate(environment: [Name: Expression] = [:]) -> Expression {
+	public func evaluate(environment: Environment = [:]) -> Expression {
 		switch destructured {
 		case let .Variable(i):
 			return environment[i] ?? self
@@ -329,7 +329,7 @@ extension Expression where Recur: FixpointType {
 extension Expression where Recur: FixpointType, Recur: Equatable {
 	// MARK: Typechecking
 
-	public func typecheck(context: [Name: Expression] = [:]) -> Either<Error, Expression> {
+	public func typecheck(context: Context = [:]) -> Either<Error, Expression> {
 		switch destructured {
 		case .Unit:
 			return .right(.UnitType)
@@ -392,7 +392,7 @@ extension Expression where Recur: FixpointType, Recur: Equatable {
 		}
 	}
 
-	public func typecheck(context: [Name: Expression], against: Expression) -> Either<Error, Expression> {
+	public func typecheck(context: Context, against: Expression) -> Either<Error, Expression> {
 		return (against.isType
 				? Either.Right(against)
 				: against.typecheck(context, against: .Type(0)))

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -95,7 +95,6 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 
 	// MARK: Environment/context construction
 
-	public typealias Environment = [Name: Expression]
 	public typealias Context = [Name: Expression]
 
 
@@ -239,6 +238,8 @@ extension Expression where Recur: FixpointType {
 
 
 	// MARK: Evaluation
+
+	public typealias Environment = [Name: Expression]
 
 	public func evaluate(environment: Environment = [:]) -> Expression {
 		switch destructured {

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -95,8 +95,13 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 
 	// MARK: Environment/context construction
 
+	public typealias Definition = (symbol: Name, value: Expression, type: Expression)
+	public typealias Environment = [Name: Expression]
+	public typealias Context = [Name: Expression]
+	public typealias Space = (environment: Environment, context: Context)
+
 	/// Construct an environment and context from symbol/value/type triples.
-	public static func environmentAndContext<S: SequenceType where S.Generator.Element == (Name, Expression, Expression)>(sequence: S) -> (environment: [Name: Expression], context: [Name: Expression]) {
+	public static func defineSpace<S: SequenceType where S.Generator.Element == Definition>(sequence: S) -> Space {
 		return sequence.reduce(([Name: Expression](), [Name: Expression]())) { into, each in
 			(into.0 + [each.0: each.1], into.1 + [each.0: each.2])
 		}

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -100,13 +100,6 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 	public typealias Context = [Name: Expression]
 	public typealias Space = (environment: Environment, context: Context)
 
-	/// Construct an environment and context from symbol/value/type triples.
-	public static func defineSpace<S: SequenceType where S.Generator.Element == Definition>(sequence: S) -> Space {
-		return sequence.reduce(([Name: Expression](), [Name: Expression]())) { into, each in
-			(into.0 + [each.0: each.1], into.1 + [each.0: each.2])
-		}
-	}
-
 
 	// MARK: BooleanLiteralConvertible
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -95,7 +95,6 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 
 	// MARK: Environment/context construction
 
-	public typealias Definition = (symbol: Name, value: Expression, type: Expression)
 	public typealias Environment = [Name: Expression]
 	public typealias Context = [Name: Expression]
 

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -93,6 +93,16 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 	}
 
 
+	// MARK: Environment/context construction
+
+	/// Construct an environment and context from symbol/value/type triples.
+	public static func environmentAndContext<S: SequenceType where S.Generator.Element == (Name, Expression, Expression)>(sequence: S) -> ([Name: Expression], [Name: Expression]) {
+		return sequence.reduce(([Name: Expression](), [Name: Expression]())) { into, each in
+			(into.0 + [each.0: each.1], into.1 + [each.0: each.2])
+		}
+	}
+
+
 	// MARK: BooleanLiteralConvertible
 
 	public init(booleanLiteral value: Bool) {

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -290,27 +290,6 @@ extension Expression where Recur: FixpointType {
 				otherwise: const(-1))
 		} (Recur(self))
 	}
-
-
-	// MARK: Hashable
-
-	var hashValue: Int {
-		return cata {
-			$0.map { $0.hashValue }.analysis(
-				ifUnit: { 1 },
-				ifUnitType: { 2 },
-				ifType: { 3 ^ $0 },
-				ifVariable: { 5 ^ $0.hashValue },
-				ifApplication: { 7 ^ $0 ^ $1 },
-				ifLambda: { 11 ^ $0 ^ $1 ^ $2 },
-				ifProjection: { 13 ^ $0 ^ $1.hashValue },
-				ifProduct: { 17 ^ $0 ^ $1 },
-				ifBooleanType: { 19 },
-				ifBoolean: { 23 ^ $0.hashValue },
-				ifIf: { 29 ^ $0 ^ $1 ^ $2 },
-				ifAnnotation: { 31 ^ $0 ^ $1 })
-		} (Recur(self))
-	}
 }
 
 extension Expression where Recur: FixpointType, Recur: Equatable {

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -93,11 +93,6 @@ public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertibl
 	}
 
 
-	// MARK: Environment/context construction
-
-	public typealias Context = [Name: Expression]
-
-
 	// MARK: BooleanLiteralConvertible
 
 	public init(booleanLiteral value: Bool) {
@@ -320,6 +315,8 @@ extension Expression where Recur: FixpointType {
 
 extension Expression where Recur: FixpointType, Recur: Equatable {
 	// MARK: Typechecking
+
+	public typealias Context = [Name: Expression]
 
 	public func typecheck(context: Context = [:]) -> Either<Error, Expression> {
 		switch destructured {

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 public enum Expression<Recur>: BooleanLiteralConvertible, CustomStringConvertible, IntegerLiteralConvertible {
 	// MARK: Analyses

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -73,9 +73,4 @@ extension FixpointType {
 }
 
 
-public func <| <Recur: FixpointType> (left: Recur, right: Recur) -> Recur {
-	return .Application(left, right)
-}
-
-
 import Prelude

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -56,11 +56,6 @@ extension FixpointType {
 	}
 
 
-	public init(_ name: Name) {
-		self.init(.Variable(name))
-	}
-
-
 	// MARK: Higher-order construction
 
 	public static func lambda(type: Self, _ body: Self -> Self) -> Self {

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -56,6 +56,11 @@ extension FixpointType {
 	}
 
 
+	public init(name: Name) {
+		self.init(.Variable(name))
+	}
+
+
 	// MARK: Higher-order construction
 
 	public static func lambda(type: Self, _ body: Self -> Self) -> Self {

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -1,6 +1,8 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension FixpointType {
+	// MARK: First-order construction
+
 	public static var Unit: Self {
 		return Self(.Unit)
 	}
@@ -51,5 +53,12 @@ extension FixpointType {
 
 	public static func Annotation(term: Self, _ type: Self) -> Self {
 		return Self(.Annotation(term, type))
+	}
+
+
+	// MARK: Higher-order construction
+
+	public static func lambda(type: Self, _ body: Self -> Self) -> Self {
+		return Self(.lambda(type, body))
 	}
 }

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -56,7 +56,7 @@ extension FixpointType {
 	}
 
 
-	public init(name: Name) {
+	public init(_ name: Name) {
 		self.init(.Variable(name))
 	}
 

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -55,6 +55,10 @@ extension FixpointType {
 		return Self(.Annotation(term, type))
 	}
 
+	public static func Axiom(value: Any, _ type: Self) -> Self {
+		return Self(.Axiom(value, type))
+	}
+
 
 	// MARK: Higher-order construction
 

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -79,6 +79,18 @@ extension FixpointType {
 	public static func lambda(type: Self, _ body: Self -> Self) -> Self {
 		return Self(.lambda(type, body))
 	}
+
+	public static func lambda(type1: Self, _ type2: Self, _ body: (Self, Self) -> Self) -> Self {
+		return Self(.lambda(type1, type2, body))
+	}
+
+	public static func lambda(type1: Self, _ type2: Self, _ type3: Self, _ body: (Self, Self, Self) -> Self) -> Self {
+		return Self(.lambda(type1, type2, type3, body))
+	}
+
+	public static func lambda(type1: Self, _ type2: Self, _ type3: Self, _ type4: Self, _ body: (Self, Self, Self, Self) -> Self) -> Self {
+		return Self(.lambda(type1, type2, type3, type4, body))
+	}
 }
 
 

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -64,7 +64,7 @@ extension FixpointType {
 }
 
 
-public func |> <Recur: FixpointType> (left: Recur, right: Recur) -> Recur {
+public func <| <Recur: FixpointType> (left: Recur, right: Recur) -> Recur {
 	return .Application(left, right)
 }
 

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -60,6 +60,11 @@ extension FixpointType {
 	}
 
 
+	public subscript (operands: Self...) -> Self {
+		return operands.reduce(self, combine: Self.Application)
+	}
+
+
 	// MARK: Higher-order construction
 
 	public static func lambda(type: Self, _ body: Self -> Self) -> Self {

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -62,3 +62,11 @@ extension FixpointType {
 		return Self(.lambda(type, body))
 	}
 }
+
+
+public func |> <Recur: FixpointType> (left: Recur, right: Recur) -> Recur {
+	return .Application(left, right)
+}
+
+
+import Prelude

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -65,6 +65,15 @@ extension FixpointType {
 	}
 
 
+	public var first: Self {
+		return .Projection(self, false)
+	}
+
+	public var second: Self {
+		return .Projection(self, true)
+	}
+
+
 	// MARK: Higher-order construction
 
 	public static func lambda(type: Self, _ body: Self -> Self) -> Self {

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -1,0 +1,55 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension FixpointType {
+	public static var unit: Self {
+		return Self(.Unit)
+	}
+
+	public static var unitType: Self {
+		return Self(.UnitType)
+	}
+
+	public static var type: Self {
+		return type(0)
+	}
+
+	public static func type(n: Int) -> Self {
+		return Self(.Type(n))
+	}
+
+	public static func variable(name: Name) -> Self {
+		return Self(.Variable(name))
+	}
+
+	public static func application(a: Self, _ b: Self) -> Self {
+		return Self(.Application(a, b))
+	}
+
+	public static func lambda(i: Int, _ type: Self, _ body: Self) -> Self {
+		return Self(.Lambda(i, type, body))
+	}
+
+	public static func projection(a: Self, _ field: Bool) -> Self {
+		return Self(.Projection(a, field))
+	}
+
+	public static func product(a: Self, _ b: Self) -> Self {
+		return Self(.Product(a, b))
+	}
+
+	public static var booleanType: Self {
+		return Self(.BooleanType)
+	}
+
+	public static func boolean(value: Bool) -> Self {
+		return Self(.Boolean(value))
+	}
+
+	public static func `if`(condition: Self, then: Self, `else`: Self) -> Self {
+		return Self(.If(condition, then, `else`))
+	}
+
+	public static func annotation(term: Self, _ type: Self) -> Self {
+		return Self(.Annotation(term, type))
+	}
+}

--- a/Manifold/FixpointType+Construction.swift
+++ b/Manifold/FixpointType+Construction.swift
@@ -1,55 +1,55 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension FixpointType {
-	public static var unit: Self {
+	public static var Unit: Self {
 		return Self(.Unit)
 	}
 
-	public static var unitType: Self {
+	public static var UnitType: Self {
 		return Self(.UnitType)
 	}
 
-	public static var type: Self {
-		return type(0)
+	public static var Type: Self {
+		return Type(0)
 	}
 
-	public static func type(n: Int) -> Self {
+	public static func Type(n: Int) -> Self {
 		return Self(.Type(n))
 	}
 
-	public static func variable(name: Name) -> Self {
+	public static func Variable(name: Name) -> Self {
 		return Self(.Variable(name))
 	}
 
-	public static func application(a: Self, _ b: Self) -> Self {
+	public static func Application(a: Self, _ b: Self) -> Self {
 		return Self(.Application(a, b))
 	}
 
-	public static func lambda(i: Int, _ type: Self, _ body: Self) -> Self {
+	public static func Lambda(i: Int, _ type: Self, _ body: Self) -> Self {
 		return Self(.Lambda(i, type, body))
 	}
 
-	public static func projection(a: Self, _ field: Bool) -> Self {
+	public static func Projection(a: Self, _ field: Bool) -> Self {
 		return Self(.Projection(a, field))
 	}
 
-	public static func product(a: Self, _ b: Self) -> Self {
+	public static func Product(a: Self, _ b: Self) -> Self {
 		return Self(.Product(a, b))
 	}
 
-	public static var booleanType: Self {
+	public static var BooleanType: Self {
 		return Self(.BooleanType)
 	}
 
-	public static func boolean(value: Bool) -> Self {
+	public static func Boolean(value: Bool) -> Self {
 		return Self(.Boolean(value))
 	}
 
-	public static func `if`(condition: Self, then: Self, `else`: Self) -> Self {
+	public static func If(condition: Self, _ then: Self, _ `else`: Self) -> Self {
 		return Self(.If(condition, then, `else`))
 	}
 
-	public static func annotation(term: Self, _ type: Self) -> Self {
+	public static func Annotation(term: Self, _ type: Self) -> Self {
 		return Self(.Annotation(term, type))
 	}
 }

--- a/Manifold/LazySequenceType.swift
+++ b/Manifold/LazySequenceType.swift
@@ -1,0 +1,7 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+public protocol LazySequenceType: SequenceType {}
+extension LazySequence: LazySequenceType {}
+extension LazyForwardCollection: LazySequenceType {}
+extension LazyBidirectionalCollection: LazySequenceType {}
+extension LazyRandomAccessCollection: LazySequenceType {}

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -13,10 +13,17 @@ extension Expression where Recur: FixpointType {
 			type: .Variable("List"))
 	}
 
+	public static var cons: Definition {
+		return (symbol: "cons",
+			value: lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(.Variable("List"), A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), .Variable("List")) } } },
+			type: .Variable("List"))
+	}
+
 	public static var list: Space {
 		return defineSpace([
 			List,
 			`nil`,
+			cons,
 		])
 	}
 }

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -1,31 +1,25 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Expression where Recur: FixpointType {
-	public static var List: Binding<Recur> {
+	public static var list: Module<Recur> {
 		// List : λ A : Type . Type
 		// List = λ A : Type . λ tag : Boolean . if tag then (A, List A) else Unit
-		return Binding("List",
+		let List = Binding("List",
 			lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(.Variable("List"), A)), .UnitType) } },
 			lambda(.Type, const(.Type)))
-	}
 
-	public static var `nil`: Binding<Recur> {
 		// nil : List
 		// nil = (false, ()) : List
-		return Binding("nil",
-			.Annotation(.Product(.Boolean(false), .Unit), .Variable("List")),
+		let `nil` = Binding("nil",
+			.Annotation(Recur.Product(.Boolean(false), .Unit), .Variable("List")),
 			.Variable("List"))
-	}
 
-	public static var cons: Binding<Recur> {
 		// cons : λ A : Type . λ _ : A . λ _ : List A . List A
 		// cons = λ A : Type . λ first : A . λ rest : List A . (true, (first, rest)) : List A
-		return Binding("cons",
+		let cons = Binding("cons",
 			lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(.Variable("List"), A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), .Variable("List")) } } },
 			.Variable("List"))
-	}
 
-	public static var list: Module<Recur> {
 		return Module([ List, `nil`, cons ])
 	}
 }

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -7,9 +7,16 @@ extension Expression where Recur: FixpointType {
 			type: lambda(.Type, const(.Type)))
 	}
 
+	public static var `nil`: Definition {
+		return (symbol: "nil",
+			value: .Annotation(.Product(.Boolean(false), .Unit), .Variable("List")),
+			type: .Variable("List"))
+	}
+
 	public static var list: Space {
 		return defineSpace([
 			List,
+			`nil`,
 		])
 	}
 }

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -26,7 +26,7 @@ extension Expression where Recur: FixpointType {
 	}
 
 	public static var list: Module<Recur> {
-		return Module(List, `nil`, cons)
+		return Module([ List, `nil`, cons ])
 	}
 }
 

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -1,28 +1,28 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Expression where Recur: FixpointType {
-	public static var List: Definition {
+	public static var List: Binding<Recur> {
 		// List : λ A : Type . Type
 		// List = λ A : Type . λ tag : Boolean . if tag then (A, List A) else Unit
-		return (symbol: "List",
-			value: lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(.Variable("List"), A)), .UnitType) } },
-			type: lambda(.Type, const(.Type)))
+		return Binding("List",
+			lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(.Variable("List"), A)), .UnitType) } },
+			lambda(.Type, const(.Type)))
 	}
 
-	public static var `nil`: Definition {
+	public static var `nil`: Binding<Recur> {
 		// nil : List
 		// nil = (false, ()) : List
-		return (symbol: "nil",
-			value: .Annotation(.Product(.Boolean(false), .Unit), .Variable("List")),
-			type: .Variable("List"))
+		return Binding("nil",
+			.Annotation(.Product(.Boolean(false), .Unit), .Variable("List")),
+			.Variable("List"))
 	}
 
-	public static var cons: Definition {
+	public static var cons: Binding<Recur> {
 		// cons : λ A : Type . λ _ : A . λ _ : List A . List A
 		// cons = λ A : Type . λ first : A . λ rest : List A . (true, (first, rest)) : List A
-		return (symbol: "cons",
-			value: lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(.Variable("List"), A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), .Variable("List")) } } },
-			type: .Variable("List"))
+		return Binding("cons",
+			lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(.Variable("List"), A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), .Variable("List")) } } },
+			.Variable("List"))
 	}
 
 	public static var list: Module<Recur> {

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -25,12 +25,8 @@ extension Expression where Recur: FixpointType {
 			type: .Variable("List"))
 	}
 
-	public static var list: Space {
-		return defineSpace([
-			List,
-			`nil`,
-			cons,
-		])
+	public static var list: Module<Recur> {
+		return Module(List, `nil`, cons)
 	}
 }
 

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -10,13 +10,13 @@ extension Expression where Recur: FixpointType {
 
 		// nil : List
 		// nil = (false, ()) : List
-		let `nil` = Binding("nil",
+		let `nil` = Binding("[]",
 			.Annotation(Recur.Product(.Boolean(false), .Unit), .Variable("List")),
 			.Variable("List"))
 
 		// cons : λ A : Type . λ _ : A . λ _ : List A . List A
 		// cons = λ A : Type . λ first : A . λ rest : List A . (true, (first, rest)) : List A
-		let cons = Binding("cons",
+		let cons = Binding("::",
 			lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(.Variable("List"), A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), .Variable("List")) } } },
 			.Variable("List"))
 

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -1,0 +1,18 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension Expression where Recur: FixpointType {
+	public static var List: Definition {
+		return (symbol: "List",
+			value: lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(.Variable("List"), A)), .UnitType) } },
+			type: lambda(.Type, const(.Type)))
+	}
+
+	public static var list: Space {
+		return defineSpace([
+			List,
+		])
+	}
+}
+
+
+import Prelude

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -2,18 +2,24 @@
 
 extension Expression where Recur: FixpointType {
 	public static var List: Definition {
+		// List : λ A : Type . Type
+		// List = λ A : Type . λ tag : Boolean . if tag then (A, List A) else Unit
 		return (symbol: "List",
 			value: lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(.Variable("List"), A)), .UnitType) } },
 			type: lambda(.Type, const(.Type)))
 	}
 
 	public static var `nil`: Definition {
+		// nil : List
+		// nil = (false, ()) : List
 		return (symbol: "nil",
 			value: .Annotation(.Product(.Boolean(false), .Unit), .Variable("List")),
 			type: .Variable("List"))
 	}
 
 	public static var cons: Definition {
+		// cons : λ A : Type . λ _ : A . λ _ : List A . List A
+		// cons = λ A : Type . λ first : A . λ rest : List A . (true, (first, rest)) : List A
 		return (symbol: "cons",
 			value: lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(.Variable("List"), A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), .Variable("List")) } } },
 			type: .Variable("List"))

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -20,7 +20,7 @@ extension Expression where Recur: FixpointType {
 		// cons = λ A : Type . λ first : A . λ rest : List A . (true, (first, rest)) : List A
 		let cons = Binding("::",
 			lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(List, A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), List) } } },
-			List.out)
+			lambda(.Type) { A in .lambda(A, const(.lambda(List[A], const(List[A])))) })
 
 		return Module([ list, `nil`, cons ])
 	}

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -2,25 +2,27 @@
 
 extension Expression where Recur: FixpointType {
 	public static var list: Module<Recur> {
+		let List = Recur("List")
+
 		// List : λ A : Type . Type
 		// List = λ A : Type . λ tag : Boolean . if tag then (A, List A) else Unit
-		let List = Binding("List",
-			lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(.Variable("List"), A)), .UnitType) } },
+		let list = Binding("List",
+			lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(List, A)), .UnitType) } },
 			lambda(.Type, const(.Type)))
 
 		// nil : List
 		// nil = (false, ()) : List
 		let `nil` = Binding("[]",
-			.Annotation(Recur.Product(.Boolean(false), .Unit), .Variable("List")),
-			.Variable("List"))
+			.Annotation(Recur.Product(.Boolean(false), .Unit), List),
+			List.out)
 
 		// cons : λ A : Type . λ _ : A . λ _ : List A . List A
 		// cons = λ A : Type . λ first : A . λ rest : List A . (true, (first, rest)) : List A
 		let cons = Binding("::",
-			lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(.Variable("List"), A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), .Variable("List")) } } },
-			.Variable("List"))
+			lambda(.Type) { A in Recur.lambda(A) { first in Recur.lambda(.Application(List, A)) { rest in .Annotation(.Product(.Boolean(true), .Product(first, rest)), List) } } },
+			List.out)
 
-		return Module([ List, `nil`, cons ])
+		return Module([ list, `nil`, cons ])
 	}
 }
 

--- a/Manifold/List.swift
+++ b/Manifold/List.swift
@@ -7,7 +7,7 @@ extension Expression where Recur: FixpointType {
 		// List : λ A : Type . Type
 		// List = λ A : Type . λ tag : Boolean . if tag then (A, List A) else Unit
 		let list = Binding("List",
-			lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, .Application(List, A)), .UnitType) } },
+			lambda(.Type) { A in Recur.lambda(.BooleanType) { .If($0, .Product(A, List[A]), .UnitType) } },
 			lambda(.Type, const(.Type)))
 
 		// nil : List

--- a/Manifold/Manifold.h
+++ b/Manifold/Manifold.h
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 /// Project version number for Manifold.
 extern double ManifoldVersionNumber;

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -9,10 +9,6 @@ public struct Module<Recur> {
 		self.definitions = Array(definitions)
 	}
 
-	public init<D: SequenceType where D.Generator.Element == Module>(_ dependencies: D, _ definitions: Binding<Recur>...) {
-		self.init(dependencies, definitions)
-	}
-
 	public init(_ definitions: Binding<Recur>...) {
 		self.init([], definitions)
 	}

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -1,25 +1,24 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 public struct Module<Recur> {
-	public typealias Binding = Expression<Recur>.Definition
 	public typealias Environment = Expression<Recur>.Environment
 	public typealias Context = Expression<Recur>.Context
 
-	public init<D: SequenceType, S: SequenceType where D.Generator.Element == Module, S.Generator.Element == Binding>(_ dependencies: D, _ definitions: S) {
+	public init<D: SequenceType, S: SequenceType where D.Generator.Element == Module, S.Generator.Element == Binding<Recur>>(_ dependencies: D, _ definitions: S) {
 		self.dependencies = Array(dependencies)
 		self.definitions = Array(definitions)
 	}
 
-	public init<D: SequenceType where D.Generator.Element == Module>(_ dependencies: D, _ definitions: Binding...) {
+	public init<D: SequenceType where D.Generator.Element == Module>(_ dependencies: D, _ definitions: Binding<Recur>...) {
 		self.init(dependencies, definitions)
 	}
 
-	public init(_ definitions: Binding...) {
+	public init(_ definitions: Binding<Recur>...) {
 		self.init([], definitions)
 	}
 
 	public let dependencies: [Module]
-	public let definitions: [Binding]
+	public let definitions: [Binding<Recur>]
 
 	public var environment: Environment {
 		let dependencies = lazy(self.dependencies).map { $0.environment }

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -1,0 +1,39 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+public struct Module<Recur> {
+	public typealias Binding = Expression<Recur>.Definition
+	public typealias Environment = Expression<Recur>.Environment
+	public typealias Context = Expression<Recur>.Context
+
+	public init<D: SequenceType, S: SequenceType where D.Generator.Element == Module, S.Generator.Element == Binding>(_ dependencies: D, _ definitions: S) {
+		self.dependencies = Array(dependencies)
+		self.definitions = Array(definitions)
+	}
+
+	public init<D: SequenceType where D.Generator.Element == Module>(_ dependencies: D, _ definitions: Binding...) {
+		self.init(dependencies, definitions)
+	}
+
+	public init(_ definitions: Binding...) {
+		self.init([], definitions)
+	}
+
+	public let dependencies: [Module]
+	public let definitions: [Binding]
+
+	public var environment: Environment {
+		let dependencies = lazy(self.dependencies).map { $0.environment }
+		let definitions = lazy(self.definitions).map { [$0.0: $0.1] }
+		return dependencies
+			.concat(definitions)
+			.reduce(Environment(), combine: +)
+	}
+
+	public var context: Context {
+		let dependencies = lazy(self.dependencies).map { $0.context }
+		let definitions = lazy(self.definitions).map { [$0.0: $0.2] }
+		return dependencies
+			.concat(definitions)
+			.reduce(Context(), combine: +)
+	}
+}

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -23,7 +23,7 @@ public struct Module<Recur> {
 
 	public var environment: Environment {
 		let dependencies = lazy(self.dependencies).map { $0.environment }
-		let definitions = lazy(self.definitions).map { [$0.0: $0.1] }
+		let definitions = lazy(self.definitions).map { [$0.symbol: $0.value] }
 		return dependencies
 			.concat(definitions)
 			.reduce(Environment(), combine: +)
@@ -31,7 +31,7 @@ public struct Module<Recur> {
 
 	public var context: Context {
 		let dependencies = lazy(self.dependencies).map { $0.context }
-		let definitions = lazy(self.definitions).map { [$0.0: $0.2] }
+		let definitions = lazy(self.definitions).map { [$0.symbol: $0.type] }
 		return dependencies
 			.concat(definitions)
 			.reduce(Context(), combine: +)

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -9,10 +9,6 @@ public struct Module<Recur> {
 		self.definitions = Array(definitions)
 	}
 
-	public init(_ definitions: Binding<Recur>...) {
-		self.init([], definitions)
-	}
-
 	public let dependencies: [Module]
 	public let definitions: [Binding<Recur>]
 

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -9,6 +9,10 @@ public struct Module<Recur> {
 		self.definitions = Array(definitions)
 	}
 
+	public init<S: SequenceType where S.Generator.Element == Binding<Recur>>(_ definitions: S) {
+		self.init([], definitions)
+	}
+
 	public let dependencies: [Module]
 	public let definitions: [Binding<Recur>]
 

--- a/Manifold/Name.swift
+++ b/Manifold/Name.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 public enum Name: CustomDebugStringConvertible, CustomStringConvertible, Hashable, IntegerLiteralConvertible, StringLiteralConvertible {
 	// MARK: Destructors

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,31 +1,25 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Expression where Recur: FixpointType {
-	public static var Natural: Binding<Recur> {
+	public static var natural: Module<Recur> {
 		// Natural : Type
 		// Natural = λ tag : Boolean . if tag then Natural else Unit
-		return Binding("Natural",
+		let Natural = Binding("Natural",
 			lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) },
 			lambda(.BooleanType, const(.Type(0))))
-	}
 
-	public static var zero: Binding<Recur> {
 		// zero : Natural
 		// zero = (false, ()) : Natural
-		return Binding("zero",
-			.Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural")),
+		let zero = Binding("zero",
+			.Annotation(Recur.Product(.Boolean(false), .Unit), .Variable("Natural")),
 			.Variable("Natural"))
-	}
 
-	public static var successor: Binding<Recur> {
 		// successor : Natural -> Natural
 		// successor = λ n : Natural . (true, n) : Natural
-		return Binding("successor",
+		let successor = Binding("successor",
 			lambda(.Variable("Natural")) { predecessor in .Annotation(.Product(.Boolean(true), predecessor), .Variable("Natural")) },
 			lambda(.Variable("Natural"), const(.Variable("Natural"))))
-	}
 
-	public static var natural: Module<Recur> {
 		return Module([ Natural, zero, successor ])
 	}
 }

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -26,7 +26,7 @@ extension Expression where Recur: FixpointType {
 	}
 
 	public static var natural: Module<Recur> {
-		return Module(Natural, zero, successor)
+		return Module([ Natural, zero, successor ])
 	}
 }
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -18,7 +18,7 @@ extension Expression where Recur: FixpointType {
 	public static var successor: Definition {
 		return (
 			symbol: "successor",
-			value: lambda(.Variable("Natural")) { predecessor in .Annotation(.lambda(.Boolean(true), const(predecessor)), .Variable("Natural")) },
+			value: lambda(.Variable("Natural")) { predecessor in .Annotation(.Product(.Boolean(true), predecessor), .Variable("Natural")) },
 			type: lambda(.Variable("Natural"), const(.Variable("Natural"))))
 	}
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,28 +1,28 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Expression where Recur: FixpointType {
-	public static var Natural: Definition {
+	public static var Natural: Binding<Recur> {
 		// Natural : Type
 		// Natural = λ tag : Boolean . if tag then Natural else Unit
-		return (symbol: "Natural",
-			value: lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) },
-			type: lambda(.BooleanType, const(.Type(0))))
+		return Binding("Natural",
+			lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) },
+			lambda(.BooleanType, const(.Type(0))))
 	}
 
-	public static var zero: Definition {
+	public static var zero: Binding<Recur> {
 		// zero : Natural
 		// zero = (false, ()) : Natural
-		return (symbol: "zero",
-			value: .Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural")),
-			type: .Variable("Natural"))
+		return Binding("zero",
+			.Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural")),
+			.Variable("Natural"))
 	}
 
-	public static var successor: Definition {
+	public static var successor: Binding<Recur> {
 		// successor : Natural -> Natural
 		// successor = λ n : Natural . (true, n) : Natural
-		return (symbol: "successor",
-			value: lambda(.Variable("Natural")) { predecessor in .Annotation(.Product(.Boolean(true), predecessor), .Variable("Natural")) },
-			type: lambda(.Variable("Natural"), const(.Variable("Natural"))))
+		return Binding("successor",
+			lambda(.Variable("Natural")) { predecessor in .Annotation(.Product(.Boolean(true), predecessor), .Variable("Natural")) },
+			lambda(.Variable("Natural"), const(.Variable("Natural"))))
 	}
 
 	public static var natural: Module<Recur> {

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -1,23 +1,32 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Expression where Recur: FixpointType {
-	public static var Natural: Expression {
-		return lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) }
+	public static var Natural: Definition {
+		return (
+			symbol: "Natural",
+			value: lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) },
+			type: lambda(.BooleanType, const(.Type(0))))
 	}
 
-	public static var zero: Expression {
-		return .Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural"))
+	public static var zero: Definition {
+		return (
+			symbol: "zero",
+			value: .Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural")),
+			type: .Variable("Natural"))
 	}
 
-	public static var successor: Expression {
-		return lambda(.Variable("Natural")) { predecessor in .Annotation(.lambda(.Boolean(true), const(predecessor)), .Variable("Natural")) }
+	public static var successor: Definition {
+		return (
+			symbol: "successor",
+			value: lambda(.Variable("Natural")) { predecessor in .Annotation(.lambda(.Boolean(true), const(predecessor)), .Variable("Natural")) },
+			type: lambda(.Variable("Natural"), const(.Variable("Natural"))))
 	}
 
 	public static var natural: Space {
 		return defineSpace([
-			("Natural", Natural, lambda(.BooleanType, const(.Type(0)))),
-			("zero", zero, .Variable("Natural")),
-			("successor", successor, lambda(.Variable("Natural"), const(.Variable("Natural"))))
+			Natural,
+			zero,
+			successor
 		])
 	}
 }

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -2,22 +2,19 @@
 
 extension Expression where Recur: FixpointType {
 	public static var Natural: Definition {
-		return (
-			symbol: "Natural",
+		return (symbol: "Natural",
 			value: lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) },
 			type: lambda(.BooleanType, const(.Type(0))))
 	}
 
 	public static var zero: Definition {
-		return (
-			symbol: "zero",
+		return (symbol: "zero",
 			value: .Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural")),
 			type: .Variable("Natural"))
 	}
 
 	public static var successor: Definition {
-		return (
-			symbol: "successor",
+		return (symbol: "successor",
 			value: lambda(.Variable("Natural")) { predecessor in .Annotation(.Product(.Boolean(true), predecessor), .Variable("Natural")) },
 			type: lambda(.Variable("Natural"), const(.Variable("Natural"))))
 	}

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -25,12 +25,8 @@ extension Expression where Recur: FixpointType {
 			type: lambda(.Variable("Natural"), const(.Variable("Natural"))))
 	}
 
-	public static var natural: Space {
-		return defineSpace([
-			Natural,
-			zero,
-			successor
-		])
+	public static var natural: Module<Recur> {
+		return Module(Natural, zero, successor)
 	}
 }
 

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -10,7 +10,7 @@ extension Expression where Recur: FixpointType {
 	}
 
 	public static var successor: Expression {
-		return lambda(Recur(.Variable("Natural"))) { predecessor in Recur(lambda(Recur(true), const(predecessor))) }
+		return lambda(Recur(.Variable("Natural"))) { predecessor in Recur(.Annotation(Recur(lambda(Recur(true), const(predecessor))), Recur(.Variable("Natural")))) }
 	}
 
 	public static var natural: Space {

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -2,18 +2,24 @@
 
 extension Expression where Recur: FixpointType {
 	public static var Natural: Definition {
+		// Natural : Type
+		// Natural = λ tag : Boolean . if tag then Natural else Unit
 		return (symbol: "Natural",
 			value: lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) },
 			type: lambda(.BooleanType, const(.Type(0))))
 	}
 
 	public static var zero: Definition {
+		// zero : Natural
+		// zero = (false, ()) : Natural
 		return (symbol: "zero",
 			value: .Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural")),
 			type: .Variable("Natural"))
 	}
 
 	public static var successor: Definition {
+		// successor : Natural -> Natural
+		// successor = λ n : Natural . (true, n) : Natural
 		return (symbol: "successor",
 			value: lambda(.Variable("Natural")) { predecessor in .Annotation(.Product(.Boolean(true), predecessor), .Variable("Natural")) },
 			type: lambda(.Variable("Natural"), const(.Variable("Natural"))))

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -2,22 +2,22 @@
 
 extension Expression where Recur: FixpointType {
 	public static var Natural: Expression {
-		return lambda(Recur(.BooleanType)) { Recur(.If($0, Recur(.Variable("Natural")), Recur(.UnitType))) }
+		return lambda(.BooleanType) { .If($0, .Variable("Natural"), .UnitType) }
 	}
 
 	public static var zero: Expression {
-		return .Annotation(Recur(.Product(Recur(false), Recur(.Unit))), Recur(.Variable("Natural")))
+		return .Annotation(.Product(.Boolean(false), .Unit), .Variable("Natural"))
 	}
 
 	public static var successor: Expression {
-		return lambda(Recur(.Variable("Natural"))) { predecessor in Recur(.Annotation(Recur(lambda(Recur(true), const(predecessor))), Recur(.Variable("Natural")))) }
+		return lambda(.Variable("Natural")) { predecessor in .Annotation(.lambda(.Boolean(true), const(predecessor)), .Variable("Natural")) }
 	}
 
 	public static var natural: Space {
 		return defineSpace([
-			("Natural", Natural, lambda(Recur(.BooleanType), const(Recur(.Type(0))))),
+			("Natural", Natural, lambda(.BooleanType, const(.Type(0)))),
 			("zero", zero, .Variable("Natural")),
-			("successor", successor, lambda(Recur(.Variable("Natural")), const(Recur(.Variable("Natural")))))
+			("successor", successor, lambda(.Variable("Natural"), const(.Variable("Natural"))))
 		])
 	}
 }

--- a/Manifold/Natural.swift
+++ b/Manifold/Natural.swift
@@ -13,20 +13,12 @@ extension Expression where Recur: FixpointType {
 		return lambda(Recur(.Variable("Natural"))) { predecessor in Recur(lambda(Recur(true), const(predecessor))) }
 	}
 
-	public static var naturalEnvironment: [Name: Expression] {
-		return [
-			"Natural": Natural,
-			"zero": zero,
-			"successor": successor,
-		]
-	}
-
-	public static var naturalContext: [Name: Expression] {
-		return [
-			"Natural": lambda(Recur(.BooleanType), const(Recur(.Type(0)))),
-			"zero": .Variable("Natural"),
-			"successor": lambda(Recur(.Variable("Natural")), const(Recur(.Variable("Natural")))),
-		]
+	public static var natural: Space {
+		return defineSpace([
+			("Natural", Natural, lambda(Recur(.BooleanType), const(Recur(.Type(0))))),
+			("zero", zero, .Variable("Natural")),
+			("successor", successor, lambda(Recur(.Variable("Natural")), const(Recur(.Variable("Natural")))))
+		])
 	}
 }
 

--- a/Manifold/ScanSequenceView.swift
+++ b/Manifold/ScanSequenceView.swift
@@ -6,20 +6,20 @@ extension SequenceType {
 	}
 }
 
-public struct ScanSequenceView<Base: SequenceType, T>: SequenceType {
-	init(sequence: Base, initial: T, combine: (T, Base.Generator.Element) -> T) {
-		self.sequence = sequence
+public struct ScanSequenceView<From, Into>: SequenceType {
+	init<Base: SequenceType where Base.Generator.Element == From>(sequence: Base, initial: Into, combine: (Into, From) -> Into) {
+		self.sequence = AnySequence(sequence)
 		self.initial = initial
 		self.combine = combine
 	}
 
-	let sequence: Base
-	let initial: T
-	let combine: (T, Base.Generator.Element) -> T
+	let sequence: AnySequence<From>
+	let initial: Into
+	let combine: (Into, From) -> Into
 
-	public func generate() -> AnyGenerator<T> {
-		var current: T? = initial
-		var generator = sequence.generate()
+	public func generate() -> AnyGenerator<Into> {
+		var current: Into? = initial
+		let generator = sequence.generate()
 		let combine = self.combine
 		return anyGenerator {
 			current.map { into in
@@ -36,7 +36,7 @@ public protocol LazySequenceType: SequenceType {
 }
 
 extension LazySequenceType {
-	public func scan<T>(initial: T, combine: (T, Generator.Element) -> T) -> LazySequence<ScanSequenceView<Self, T>> {
+	public func scan<Into>(initial: Into, combine: (Into, Generator.Element) -> Into) -> LazySequence<ScanSequenceView<Generator.Element, Into>> {
 		return lazy(ScanSequenceView(sequence: self, initial: initial, combine: combine))
 	}
 }

--- a/Manifold/ScanSequenceView.swift
+++ b/Manifold/ScanSequenceView.swift
@@ -42,17 +42,17 @@ extension LazySequenceType {
 }
 
 extension LazySequence: LazySequenceType {
-	public typealias Sequence = S
+	public typealias Sequence = Base
 }
 
 extension LazyForwardCollection: LazySequenceType {
-	public typealias Sequence = S
+	public typealias Sequence = Base
 }
 
 extension LazyBidirectionalCollection: LazySequenceType {
-	public typealias Sequence = S
+	public typealias Sequence = Base
 }
 
 extension LazyRandomAccessCollection: LazySequenceType {
-	public typealias Sequence = S
+	public typealias Sequence = Base
 }

--- a/Manifold/ScanSequenceView.swift
+++ b/Manifold/ScanSequenceView.swift
@@ -31,28 +31,14 @@ public struct ScanSequenceView<From, Into>: SequenceType {
 }
 
 
-public protocol LazySequenceType: SequenceType {
-	typealias Sequence: SequenceType
-}
+public protocol LazySequenceType: SequenceType {}
+extension LazySequence: LazySequenceType {}
+extension LazyForwardCollection: LazySequenceType {}
+extension LazyBidirectionalCollection: LazySequenceType {}
+extension LazyRandomAccessCollection: LazySequenceType {}
 
 extension LazySequenceType {
 	public func scan<Into>(initial: Into, combine: (Into, Generator.Element) -> Into) -> LazySequence<ScanSequenceView<Generator.Element, Into>> {
 		return lazy(ScanSequenceView(sequence: self, initial: initial, combine: combine))
 	}
-}
-
-extension LazySequence: LazySequenceType {
-	public typealias Sequence = Base
-}
-
-extension LazyForwardCollection: LazySequenceType {
-	public typealias Sequence = Base
-}
-
-extension LazyBidirectionalCollection: LazySequenceType {
-	public typealias Sequence = Base
-}
-
-extension LazyRandomAccessCollection: LazySequenceType {
-	public typealias Sequence = Base
 }

--- a/Manifold/ScanSequenceView.swift
+++ b/Manifold/ScanSequenceView.swift
@@ -30,13 +30,6 @@ public struct ScanSequenceView<From, Into>: SequenceType {
 	}
 }
 
-
-public protocol LazySequenceType: SequenceType {}
-extension LazySequence: LazySequenceType {}
-extension LazyForwardCollection: LazySequenceType {}
-extension LazyBidirectionalCollection: LazySequenceType {}
-extension LazyRandomAccessCollection: LazySequenceType {}
-
 extension LazySequenceType {
 	public func scan<Into>(initial: Into, combine: (Into, Generator.Element) -> Into) -> LazySequence<ScanSequenceView<Generator.Element, Into>> {
 		return lazy(ScanSequenceView(sequence: self, initial: initial, combine: combine))

--- a/Manifold/StringLiteralConvertible.swift
+++ b/Manifold/StringLiteralConvertible.swift
@@ -1,11 +1,11 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
-extension StringLiteralConvertible where StringLiteralType == String {
-	public init(unicodeScalarLiteral: String) {
+extension StringLiteralConvertible {
+	public init(unicodeScalarLiteral: Self.StringLiteralType) {
 		self.init(stringLiteral: unicodeScalarLiteral)
 	}
 
-	public init(extendedGraphemeClusterLiteral: String) {
+	public init(extendedGraphemeClusterLiteral: Self.StringLiteralType) {
 		self.init(stringLiteral: extendedGraphemeClusterLiteral)
 	}
 }

--- a/Manifold/StringLiteralConvertible.swift
+++ b/Manifold/StringLiteralConvertible.swift
@@ -1,0 +1,11 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension StringLiteralConvertible where StringLiteralType == String {
+	public init(unicodeScalarLiteral: String) {
+		self.init(stringLiteral: unicodeScalarLiteral)
+	}
+
+	public init(extendedGraphemeClusterLiteral: String) {
+		self.init(stringLiteral: extendedGraphemeClusterLiteral)
+	}
+}

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -30,5 +30,13 @@ public struct Term: CustomStringConvertible, FixpointType, Hashable {
 }
 
 
+// This would be an extension on `FixpointType` if protocol extensions could have inheritance clauses.
+extension Term: BooleanLiteralConvertible {
+	public init(booleanLiteral: Bool) {
+		self = .boolean(booleanLiteral)
+	}
+}
+
+
 import Either
 import Prelude

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -33,11 +33,11 @@ public struct Term: CustomStringConvertible, FixpointType, Hashable {
 // This would be an extension on `FixpointType` if protocol extensions could have inheritance clauses.
 extension Term: BooleanLiteralConvertible, StringLiteralConvertible {
 	public init(booleanLiteral: Bool) {
-		self = .boolean(booleanLiteral)
+		self = .Boolean(booleanLiteral)
 	}
 
 	public init(stringLiteral: String) {
-		self = .variable(.Global(stringLiteral))
+		self = .Variable(.Global(stringLiteral))
 	}
 }
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -31,9 +31,13 @@ public struct Term: CustomStringConvertible, FixpointType, Hashable {
 
 
 // This would be an extension on `FixpointType` if protocol extensions could have inheritance clauses.
-extension Term: BooleanLiteralConvertible {
+extension Term: BooleanLiteralConvertible, StringLiteralConvertible {
 	public init(booleanLiteral: Bool) {
 		self = .boolean(booleanLiteral)
+	}
+
+	public init(stringLiteral: String) {
+		self = .variable(.Global(stringLiteral))
 	}
 }
 

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 public struct Term: CustomStringConvertible, FixpointType, Hashable {
 	private var expression: () -> Expression<Term>

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -1,6 +1,6 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
-public struct Term: CustomStringConvertible, FixpointType, Hashable {
+public struct Term: CustomStringConvertible, FixpointType {
 	private var expression: () -> Expression<Term>
 
 
@@ -19,13 +19,6 @@ public struct Term: CustomStringConvertible, FixpointType, Hashable {
 
 	public var out: Expression<Term> {
 		return expression()
-	}
-
-
-	// MARK: Hashable
-
-	public var hashValue: Int {
-		return out.hashValue
 	}
 }
 

--- a/ManifoldTests/ExpressionTests.swift
+++ b/ManifoldTests/ExpressionTests.swift
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015 Rob Rix. All rights reserved.
+//  Copyright © 2015 Rob Rix. All rights reserved.
 
 final class ExpressionTests: XCTestCase {
 	func testLambdaTypeDescription() {

--- a/ManifoldTests/ListTests.swift
+++ b/ManifoldTests/ListTests.swift
@@ -4,6 +4,7 @@ final class ListTests: XCTestCase {
 	func testListTypechecks() {
 		let kind = Expression<Term>.Variable("List").typecheck(Expression.list.context)
 		assert(kind.left, ==, nil)
+		assert(kind.right, ==, .lambda(.Type, const(.Type)))
 	}
 }
 

--- a/ManifoldTests/ListTests.swift
+++ b/ManifoldTests/ListTests.swift
@@ -1,0 +1,12 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+final class ListTests: XCTestCase {
+	func testListTypechecks() {
+		let kind = Expression<Term>.Variable("List").typecheck(Expression.list.context)
+		assert(kind.left, ==, nil)
+	}
+}
+
+import Assertions
+@testable import Manifold
+import XCTest

--- a/ManifoldTests/NaturalTests.swift
+++ b/ManifoldTests/NaturalTests.swift
@@ -2,11 +2,11 @@
 
 final class NaturalTests: XCTestCase {
 	func testZeroTypechecksAsNatural() {
-		assert(zero.typecheck(Expression<Term>.naturalContext).right, ==, .Variable("Natural"))
+		assert(zero.typecheck(Expression<Term>.natural.context).right, ==, .Variable("Natural"))
 	}
 
 	func testSuccessorOfZeroTypechecksAsNatural() {
-		let typechecked = Term(.Application(Term(.Variable("successor")), Term(.Variable("zero")))).out.typecheck(Expression<Term>.naturalContext)
+		let typechecked = Term(.Application(Term(.Variable("successor")), Term(.Variable("zero")))).out.typecheck(Expression<Term>.natural.context)
 		assert(typechecked.right, ==, .Variable("Natural"))
 	}
 }

--- a/ManifoldTests/TypecheckingTests.swift
+++ b/ManifoldTests/TypecheckingTests.swift
@@ -52,7 +52,7 @@ final class TypecheckingTests: XCTestCase {
 }
 
 import Assertions
-import Manifold
+@testable import Manifold
 import Prelude
 import XCTest
 


### PR DESCRIPTION
```
CompileSwift normal x86_64
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ListTests.swift
cd /Users/rob/Developer/Projects/Manifold

/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.
xctoolchain/usr/bin/swift -frontend -c
/Users/rob/Developer/Projects/Manifold/ManifoldTests/NaturalTests.swift
-primary-file
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ListTests.swift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/DoubleExtensionTest
s.swift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ExpressionTests.swi
ft
/Users/rob/Developer/Projects/Manifold/ManifoldTests/TypecheckingTests.s
wift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ScanSequenceViewTes
ts.swift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/EvaluationTests.swi
ft
/Users/rob/Developer/Projects/Manifold/ManifoldTests/IntExtensionTests.s
wift -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platfor
m/Developer/SDKs/MacOSX10.11.sdk -I
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Products/Debug -F
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Products/Debug -F
/Applications/Xcode-beta.app/Contents/Developer/Library/Frameworks -F
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platfor
m/Developer/Library/Frameworks -enable-testing -g -module-cache-path
/Users/rob/Library/Developer/Xcode/DerivedData/ModuleCache
-serialize-debugging-options -serialize-debugging-options -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/swift-overrides.hmap -Xcc -iquote -Xcc
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/ManifoldTests-generated-files.hmap -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/ManifoldTests-own-target-headers.hmap -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/ManifoldTests-all-non-framework-target-headers.hmap -Xcc
-ivfsoverlay -Xcc
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/all-product-headers.yaml
-Xcc -iquote -Xcc
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/ManifoldTests-project-headers.hmap -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Products/Debug/include -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/DerivedSources/x86_64 -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/DerivedSources -Xcc -DDEBUG=1 -Xcc -DDEBUG=1 -Xcc
-working-directory/Users/rob/Developer/Projects/Manifold
-emit-module-doc-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests~partial.swiftdoc -Onone -module-name
ManifoldTests -emit-module-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests~partial.swiftmodule
-serialize-diagnostics-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.dia -emit-dependencies-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.d -emit-reference-dependencies-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.swiftdeps -o
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.o

TYPE MISMATCH IN ARGUMENT 0 OF APPLY AT expression at
[/Users/rob/Developer/Projects/Manifold/ManifoldTests/ListTests.swift:7:
34 - line:7:35] RangeText=".T"
argument value:   %3 = metatype $@thin Term.Type
parameter type: @thick Term.Type
0  swift                    0x000000010d7c201b
llvm::sys::PrintStackTrace(__sFILE*) + 43
1  swift                    0x000000010d7c275b SignalHandler(int) + 379
2  libsystem_platform.dylib 0x00007fff8dd93f1a _sigtramp + 26
3  libsystem_platform.dylib 0x0000000000000005 _sigtramp + 1915142405
4  swift                    0x000000010d7c2556 abort + 22
5  swift                    0x000000010b9c3a7f
swift::Lowering::SILGenFunction::emitApply(swift::SILLocation,
swift::Lowering::ManagedValue, llvm::ArrayRef<swift::Substitution>,
llvm::ArrayRef<swift::Lowering::ManagedValue>,
swift::CanTypeWrapper<swift::SILFunctionType>,
swift::Lowering::AbstractionPattern, swift::CanType,
swift::Lowering::ApplyOptions,
llvm::Optional<swift::SILFunctionTypeRepresentation>,
llvm::Optional<swift::ForeignErrorConvention> const&,
swift::Lowering::SGFContext) + 6415
6  swift                    0x000000010b9c5664 (anonymous
namespace)::CallEmission::apply(swift::Lowering::SGFContext) + 4052
7  swift                    0x000000010b9c9518
swift::Lowering::SILGenFunction::emitGetAccessor(swift::SILLocation,
swift::SILDeclRef, llvm::ArrayRef<swift::Substitution>,
swift::Lowering::ArgumentSource&&, bool, bool,
swift::Lowering::RValue&&, swift::Lowering::SGFContext) + 664
8  swift                    0x000000010ba2b800 (anonymous
namespace)::GetterSetterComponent::get(swift::Lowering::SILGenFunction&,
swift::SILLocation, swift::Lowering::ManagedValue,
swift::Lowering::SGFContext) && + 256
9  swift                    0x000000010ba28539
swift::Lowering::SILGenFunction::emitLoadOfLValue(swift::SILLocation,
swift::Lowering::LValue&&, swift::Lowering::SGFContext, bool) + 441
10 swift                    0x000000010ba0a0ff
swift::ASTVisitor<(anonymous namespace)::RValueEmitter,
swift::Lowering::RValue, void, void, void, void, void,
swift::Lowering::SGFContext>::visit(swift::Expr*,
swift::Lowering::SGFContext) + 25455
11 swift                    0x000000010ba0189d
swift::Lowering::SILGenFunction::emitRValueAsSingleValue(swift::Expr*,
swift::Lowering::SGFContext) + 61
12 swift                    0x000000010b9ac777
swift::Lowering::ArgumentSource::getAsSingleValue(swift::Lowering::SILGe
nFunction&, swift::Lowering::SGFContext) && + 439
13 swift                    0x000000010b9d5151 (anonymous
namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 2769
14 swift                    0x000000010b9d5b78 (anonymous
namespace)::ArgEmitter::emitExpanded(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 1048
15 swift                    0x000000010b9d4adb (anonymous
namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 1115
16 swift                    0x000000010b9d3f34 (anonymous
namespace)::CallSite::emit(swift::Lowering::SILGenFunction&,
swift::Lowering::AbstractionPattern, (anonymous
namespace)::ParamLowering&,
llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&,
llvm::SmallVectorImpl<std::__1::pair<swift::Lowering::LValue,
swift::SILLocation> >&, llvm::Optional<swift::ForeignErrorConvention>
const&) && + 244
17 swift                    0x000000010b9c52c0 (anonymous
namespace)::CallEmission::apply(swift::Lowering::SGFContext) + 3120
18 swift                    0x000000010b9c415a
swift::Lowering::SILGenFunction::emitApplyExpr(swift::Expr*,
swift::Lowering::SGFContext) + 58
19 swift                    0x000000010ba03de7
swift::ASTVisitor<(anonymous namespace)::RValueEmitter,
swift::Lowering::RValue, void, void, void, void, void,
swift::Lowering::SGFContext>::visit(swift::Expr*,
swift::Lowering::SGFContext) + 87
20 swift                    0x000000010b9fd70f
swift::Lowering::SILGenFunction::emitExprInto(swift::Expr*,
swift::Lowering::Initialization*) + 303
21 swift                    0x000000010ba53457
swift::Lowering::SILGenFunction::emitReturnExpr(swift::SILLocation,
swift::Expr*) + 215
22 swift                    0x000000010ba1836e
swift::Lowering::SILGenFunction::emitClosure(swift::AbstractClosureExpr*
) + 286
23 swift                    0x000000010b9b81e0
swift::Lowering::SILGenModule::emitClosure(swift::AbstractClosureExpr*)
+ 240
24 swift                    0x000000010ba0dedb (anonymous
namespace)::RValueEmitter::visitAbstractClosureExpr(swift::AbstractClosu
reExpr*, swift::Lowering::SGFContext) + 107
25 swift                    0x000000010ba03e27
swift::ASTVisitor<(anonymous namespace)::RValueEmitter,
swift::Lowering::RValue, void, void, void, void, void,
swift::Lowering::SGFContext>::visit(swift::Expr*,
swift::Lowering::SGFContext) + 151
26 swift                    0x000000010b9fd863
swift::Lowering::SILGenFunction::emitRValue(swift::Expr*,
swift::Lowering::SGFContext) + 35
27 swift                    0x000000010b9d4a0c (anonymous
namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 908
28 swift                    0x000000010b9d5b78 (anonymous
namespace)::ArgEmitter::emitExpanded(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 1048
29 swift                    0x000000010b9d4adb (anonymous
namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 1115
30 swift                    0x000000010b9d6c61 (anonymous
namespace)::ArgEmitter::emitShuffle(swift::Expr*, swift::Expr*,
llvm::ArrayRef<swift::TupleTypeElt>, swift::ConcreteDeclRef,
llvm::ArrayRef<swift::Expr*>, llvm::ArrayRef<int>, swift::Type,
swift::Lowering::AbstractionPattern) + 3425
31 swift                    0x000000010b9d5c5a (anonymous
namespace)::ArgEmitter::emitExpanded(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 1274
32 swift                    0x000000010b9d4adb (anonymous
namespace)::ArgEmitter::emit(swift::Lowering::ArgumentSource&&,
swift::Lowering::AbstractionPattern) + 1115
33 swift                    0x000000010b9d3f34 (anonymous
namespace)::CallSite::emit(swift::Lowering::SILGenFunction&,
swift::Lowering::AbstractionPattern, (anonymous
namespace)::ParamLowering&,
llvm::SmallVectorImpl<swift::Lowering::ManagedValue>&,
llvm::SmallVectorImpl<std::__1::pair<swift::Lowering::LValue,
swift::SILLocation> >&, llvm::Optional<swift::ForeignErrorConvention>
const&) && + 244
34 swift                    0x000000010b9c52c0 (anonymous
namespace)::CallEmission::apply(swift::Lowering::SGFContext) + 3120
35 swift                    0x000000010b9c415a
swift::Lowering::SILGenFunction::emitApplyExpr(swift::Expr*,
swift::Lowering::SGFContext) + 58
36 swift                    0x000000010ba03de7
swift::ASTVisitor<(anonymous namespace)::RValueEmitter,
swift::Lowering::RValue, void, void, void, void, void,
swift::Lowering::SGFContext>::visit(swift::Expr*,
swift::Lowering::SGFContext) + 87
37 swift                    0x000000010ba01b6d
swift::Lowering::SILGenFunction::emitIgnoredExpr(swift::Expr*) + 445
38 swift                    0x000000010ba50678
swift::ASTVisitor<(anonymous namespace)::StmtEmitter, void, void, void,
void, void, void>::visit(swift::Stmt*) + 536
39 swift                    0x000000010ba50455
swift::Lowering::SILGenFunction::emitStmt(swift::Stmt*) + 21
40 swift                    0x000000010ba18196
swift::Lowering::SILGenFunction::emitFunction(swift::FuncDecl*) + 390
41 swift                    0x000000010b9b6701
swift::Lowering::SILGenModule::emitFunction(swift::FuncDecl*) + 513
42 swift                    0x000000010ba561dc (anonymous
namespace)::SILGenType::emitType() + 956
43 swift                    0x000000010ba55d7e
swift::Lowering::SILGenModule::visitNominalTypeDecl(swift::NominalTypeDe
cl*) + 30
44 swift                    0x000000010b9ba6cb
swift::Lowering::SILGenModule::emitSourceFile(swift::SourceFile*,
unsigned int) + 587
45 swift                    0x000000010b9bb55f
swift::SILModule::constructSIL(swift::ModuleDecl*, swift::SILOptions&,
swift::FileUnit*, llvm::Optional<unsigned int>, bool, bool) + 975
46 swift                    0x000000010b9bb9bb
swift::performSILGeneration(swift::FileUnit&, swift::SILOptions&,
llvm::Optional<unsigned int>, bool) + 123
47 swift                    0x000000010b7b4e51
performCompile(swift::CompilerInstance&, swift::CompilerInvocation&,
llvm::ArrayRef<char const*>, int&) + 9153
48 swift                    0x000000010b7b2873
frontend_main(llvm::ArrayRef<char const*>, char const*, void*) + 2515
49 swift                    0x000000010b7ae9ff main + 1983
50 libdyld.dylib            0x00007fff8dc3f5c9 start + 1
51 libdyld.dylib            0x000000000000004c start + 1916537476
Stack dump:
0.  Program arguments:
/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.
xctoolchain/usr/bin/swift -frontend -c
/Users/rob/Developer/Projects/Manifold/ManifoldTests/NaturalTests.swift
-primary-file
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ListTests.swift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/DoubleExtensionTest
s.swift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ExpressionTests.swi
ft
/Users/rob/Developer/Projects/Manifold/ManifoldTests/TypecheckingTests.s
wift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ScanSequenceViewTes
ts.swift
/Users/rob/Developer/Projects/Manifold/ManifoldTests/EvaluationTests.swi
ft
/Users/rob/Developer/Projects/Manifold/ManifoldTests/IntExtensionTests.s
wift -target x86_64-apple-macosx10.9 -enable-objc-interop -sdk
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platfor
m/Developer/SDKs/MacOSX10.11.sdk -I
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Products/Debug -F
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Products/Debug -F
/Applications/Xcode-beta.app/Contents/Developer/Library/Frameworks -F
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platfor
m/Developer/Library/Frameworks -enable-testing -g -module-cache-path
/Users/rob/Library/Developer/Xcode/DerivedData/ModuleCache
-serialize-debugging-options -serialize-debugging-options -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/swift-overrides.hmap -Xcc -iquote -Xcc
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/ManifoldTests-generated-files.hmap -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/ManifoldTests-own-target-headers.hmap -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/ManifoldTests-all-non-framework-target-headers.hmap -Xcc
-ivfsoverlay -Xcc
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/all-product-headers.yaml
-Xcc -iquote -Xcc
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/ManifoldTests-project-headers.hmap -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Products/Debug/include -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/DerivedSources/x86_64 -Xcc
-I/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatu
bqlsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.bu
ild/DerivedSources -Xcc -DDEBUG=1 -Xcc -DDEBUG=1 -Xcc
-working-directory/Users/rob/Developer/Projects/Manifold
-emit-module-doc-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests~partial.swiftdoc -Onone -module-name
ManifoldTests -emit-module-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests~partial.swiftmodule
-serialize-diagnostics-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.dia -emit-dependencies-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.d -emit-reference-dependencies-path
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.swiftdeps -o
/Users/rob/Library/Developer/Xcode/DerivedData/Manifold-epkikerqiriatubq
lsmvsfowfovp/Build/Intermediates/Manifold.build/Debug/ManifoldTests.buil
d/Objects-normal/x86_64/ListTests.o
1.  While emitting SIL for 'testListTypechecksAsType' at
/Users/rob/Developer/Projects/Manifold/ManifoldTests/ListTests.swift:4:2
2.  While silgen closureexpr SIL function
@_TFFC13ManifoldTests9ListTests24testListTypechecksAsTypeFS0_FT_T_u2_KT_
GO8Manifold10ExpressionVS1_4Term_ for expression at
[/Users/rob/Developer/Projects/Manifold/ManifoldTests/ListTests.swift:7:
26 - line:7:53] RangeText=".lambda(.Type, const(.Type))"
```
