### PR TITLE
Remove the default case for inference.

### DIFF
--- a/Manifold/Expression+Inference.swift
+++ b/Manifold/Expression+Inference.swift
@@ -61,9 +61,6 @@ extension Expression where Recur: TermType, Recur: Equatable {
 		case let .Annotation(term, type):
 			return annotate(term.checkType(type, environment, context)
 				.map(const(type)))
-
-		default:
-			return Either.Left("Cannot infer type for \(self). Try annotating?")
 		}
 	}
 }


### PR DESCRIPTION
Inference is already exhaustive.
