### PR TITLE
Insert wildcards for unused parameters

### DIFF
--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		D44541901BCB028A00F2946D /* TermType+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D445418F1BCB028A00F2946D /* TermType+CustomDebugStringConvertible.swift */; };
 		D44541921BCB030F00F2946D /* TermType+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44541911BCB030F00F2946D /* TermType+CustomStringConvertible.swift */; };
 		D44541941BCB389400F2946D /* TypeConstructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44541931BCB389400F2946D /* TypeConstructor.swift */; };
-		D4809FBD1AF6BD400084B8FE /* ExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* ExpressionTests.swift */; };
+		D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4809FBC1AF6BD400084B8FE /* TermTests.swift */; };
 		D48404B81BC36F88006EABAC /* DatatypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48404B71BC36F88006EABAC /* DatatypeTests.swift */; };
 		D484903C1B2A40E800F249F7 /* EvaluationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D484903B1B2A40E800F249F7 /* EvaluationTests.swift */; };
 		D4A31B2A1AA366EC00B3FC68 /* TermType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A31B291AA366EC00B3FC68 /* TermType.swift */; };
@@ -94,7 +94,7 @@
 		D445418F1BCB028A00F2946D /* TermType+CustomDebugStringConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TermType+CustomDebugStringConvertible.swift"; sourceTree = "<group>"; };
 		D44541911BCB030F00F2946D /* TermType+CustomStringConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TermType+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		D44541931BCB389400F2946D /* TypeConstructor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypeConstructor.swift; sourceTree = "<group>"; };
-		D4809FBC1AF6BD400084B8FE /* ExpressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpressionTests.swift; sourceTree = "<group>"; };
+		D4809FBC1AF6BD400084B8FE /* TermTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermTests.swift; sourceTree = "<group>"; };
 		D48404B71BC36F88006EABAC /* DatatypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatatypeTests.swift; sourceTree = "<group>"; };
 		D484903B1B2A40E800F249F7 /* EvaluationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EvaluationTests.swift; sourceTree = "<group>"; };
 		D4A31B291AA366EC00B3FC68 /* TermType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TermType.swift; sourceTree = "<group>"; };
@@ -230,7 +230,7 @@
 			children = (
 				D4F1B8581B470E8E0065BF22 /* DoubleExtensionTests.swift */,
 				D484903B1B2A40E800F249F7 /* EvaluationTests.swift */,
-				D4809FBC1AF6BD400084B8FE /* ExpressionTests.swift */,
+				D4809FBC1AF6BD400084B8FE /* TermTests.swift */,
 				D4F1B8541B470B430065BF22 /* IntExtensionTests.swift */,
 				D4E101B71B484606001A7E55 /* NaturalTests.swift */,
 				D4F1B8521B46FD4F0065BF22 /* LazyScanSequenceTests.swift */,
@@ -421,7 +421,7 @@
 				D4E101B81B484606001A7E55 /* NaturalTests.swift in Sources */,
 				D4F969981B98F3220069F481 /* Term+Arbitrary.swift in Sources */,
 				D4F1B8591B470E8E0065BF22 /* DoubleExtensionTests.swift in Sources */,
-				D4809FBD1AF6BD400084B8FE /* ExpressionTests.swift in Sources */,
+				D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */,
 				D48404B81BC36F88006EABAC /* DatatypeTests.swift in Sources */,
 				D43AC8871BC1831F008762B7 /* TelescopeTests.swift in Sources */,
 				D44541821BCAE3CD00F2946D /* ListTests.swift in Sources */,

--- a/Manifold/Declaration.swift
+++ b/Manifold/Declaration.swift
@@ -61,7 +61,10 @@ extension Declaration where Recur: TermType {
 	}
 
 	public func typecheck(environment: [Name:Recur], _ context: [Name:Recur]) -> [Error] {
-		return definitions.flatMap { $2.checkType($1, environment, context).left }
+		let symbol = self.symbol
+		return definitions
+			.flatMap { $2.checkType($1, environment, context).left }
+			.map { $0.map { "\(symbol): \($0)" } }
 	}
 }
 

--- a/Manifold/Declaration.swift
+++ b/Manifold/Declaration.swift
@@ -63,7 +63,7 @@ extension Declaration where Recur: TermType {
 	public func typecheck(environment: [Name:Recur], _ context: [Name:Recur]) -> [Error] {
 		let symbol = self.symbol
 		return definitions
-			.flatMap { $2.checkType($1, environment, context).left }
+			.flatMap { symbol, type, value in value.checkType(type, environment, context).left.map { $0.map { "\(symbol): \($0)" } } }
 			.map { $0.map { "\(symbol): \($0)" } }
 	}
 }

--- a/Manifold/Int.swift
+++ b/Manifold/Int.swift
@@ -2,7 +2,7 @@
 
 extension Int {
 	public func digits(base: Int) -> [Int] {
-		return 0.stride(to: self == 0 ? 0 : Int(Double(self).log(Double(base))), by: 1)
+		return 0.stride(to: self <= 0 ? 0 : Int(Double(self).log(Double(base))), by: 1)
 			.lazy
 			.scan(self) { into, _ in
 				into / base

--- a/Manifold/TermType+Checking.swift
+++ b/Manifold/TermType+Checking.swift
@@ -14,9 +14,9 @@ extension TermType {
 		case (.Type, .Type):
 			return .Right(against)
 
-		case let (.Lambda(i, type, body), .Lambda(_, Self(.Type(0)), bodyType)):
+		case let (.Lambda(i, type, body), .Lambda(j, Self(.Type(0)), bodyType)):
 			return type.checkIsType(environment, context)
-				>> body.checkType(bodyType, environment, context + [ Name.Local(i) : type ])
+				>> body.checkType(bodyType.substitute(j, .Variable(.Local(i))), environment, context + [ Name.Local(i) : type ])
 					.map(const(against))
 
 		case let (.Lambda(i, type, body), .Type):

--- a/Manifold/TermType+Construction.swift
+++ b/Manifold/TermType+Construction.swift
@@ -97,6 +97,7 @@ extension TermType {
 		var n = -1
 		let body = body(Self { .Variable(.Local(n)) })
 		n = body.maxBoundVariable + 1
+		if !body.freeVariables.contains(n) { n = -1 }
 		return .Lambda(n, type, body)
 	}
 

--- a/Manifold/TermType+Construction.swift
+++ b/Manifold/TermType+Construction.swift
@@ -94,7 +94,7 @@ extension TermType {
 	// MARK: Higher-order construction
 
 	public static func lambda(type: Self, _ body: Self -> Self) -> Self {
-		var n = 0
+		var n = -1
 		let body = body(Self { .Variable(.Local(n)) })
 		n = body.maxBoundVariable + 1
 		return .Lambda(n, type, body)

--- a/Manifold/TermType+CustomStringConvertible.swift
+++ b/Manifold/TermType+CustomStringConvertible.swift
@@ -58,8 +58,9 @@ extension TermType {
 	}
 }
 
-private func atModular<C: CollectionType>(collection: C, offset: C.Index.Distance) -> C.Generator.Element {
-	return collection[collection.startIndex.advancedBy(offset % collection.startIndex.distanceTo(collection.endIndex), limit: collection.endIndex)]
+private func atModular<C: CollectionType where C.Index: BidirectionalIndexType>(collection: C, offset: C.Index.Distance) -> C.Generator.Element {
+	let max = collection.startIndex.distanceTo(collection.endIndex)
+	return collection[(offset >= 0 ? collection.startIndex : collection.endIndex).advancedBy(offset % max, limit: offset >= 0 ? collection.endIndex : collection.startIndex)]
 }
 
 

--- a/Manifold/TermType+Inference.swift
+++ b/Manifold/TermType+Inference.swift
@@ -27,7 +27,7 @@ extension TermType {
 			return .right(.Type(n + 1))
 
 		case let .Variable(i):
-			return context[i].map(Either.Right) ?? Either.Left("Unexpectedly free variable \(i) in context: \(Self.toString(context)), environment: \(Self.toString(environment))")
+			return context[i].map(Either.Right) ?? Either.Left("Unexpectedly free variable \(Self.describe(i)) in context: \(Self.toString(context)), environment: \(Self.toString(environment))")
 
 		case let .Lambda(i, type, body):
 			return type.checkIsType(environment, context)

--- a/Manifold/TermType+Inference.swift
+++ b/Manifold/TermType+Inference.swift
@@ -36,7 +36,7 @@ extension TermType {
 
 		case let .Product(a, b):
 			return (a.inferType(environment, context) &&& b.inferType(environment, context))
-				.map { A, B in Self.lambda(A, const(B)) }
+				.map { A, B in .lambda(A, const(B)) }
 
 		case let .Application(a, b):
 			return a.inferType(environment, context)

--- a/Manifold/TermType+Inference.swift
+++ b/Manifold/TermType+Inference.swift
@@ -32,7 +32,7 @@ extension TermType {
 		case let .Lambda(i, type, body):
 			return type.checkIsType(environment, context)
 				>> body.inferType(environment, context + [ .Local(i): type ])
-					.map { Self.lambda(type, const($0)) }
+					.map { b in .lambda(type, { b.substitute(i, $0) }) }
 
 		case let .Product(a, b):
 			return (a.inferType(environment, context) &&& b.inferType(environment, context))

--- a/Manifold/TypeConstructor.swift
+++ b/Manifold/TypeConstructor.swift
@@ -24,8 +24,9 @@ public enum TypeConstructor<Recur: TermType>: DictionaryLiteralConvertible {
 				}
 			})
 		case let .End(datatype):
-			return datatype.definitions().map { symbol, type, value in
-				(symbol, abstract(type)(recur), abstract(value)(recur))
+			return datatype.definitions().map {
+				// Since at this point the type and value both close over the same parameter despite its inevitable use at two different indices, we copy them recursively using `Recur(term:)` to ensure that they’re finished with the shared state by the time they’re returned to the caller.
+				($0, Recur(term: abstract($1)(recur)), Recur(term: abstract($2)(recur)))
 			}
 		}
 	}

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -50,6 +50,10 @@ final class TermTests: XCTestCase {
 	func testFreeVariablesDoNotIncludeThoseBoundByLambdas() {
 		assert(Term.Lambda(1, .UnitType, 1).freeVariables, ==, [])
 	}
+
+	func testLambdasDoNotShadowFreeVariablesInTheirTypes() {
+		assert(Term.Lambda(1, 1, 1).freeVariables, ==, [ 1 ])
+	}
 }
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -46,6 +46,10 @@ final class TermTests: XCTestCase {
 	func testSubstitution() {
 		assert(Term.Lambda(0, 1, 0).substitute(1, .Unit), ==, .Lambda(0, .Unit, 0))
 	}
+
+	func testFreeVariablesDoNotIncludeThoseBoundByLambdas() {
+		assert(Term.Lambda(1, .UnitType, 1).freeVariables, ==, [])
+	}
 }
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -1,6 +1,6 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
-final class ExpressionTests: XCTestCase {
+final class TermTests: XCTestCase {
 	func testLambdaTypeDescription() {
 		assert(identity.description, ==, "λ b : Type . λ a : b . a")
 		assert(identity.inferType().right?.description, ==, "λ b : Type . b → b")

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -3,7 +3,7 @@
 final class TermTests: XCTestCase {
 	func testLambdaTypeDescription() {
 		assert(identity.description, ==, "λ b : Type . λ a : b . a")
-		assert(identity.inferType().right?.description, ==, "λ b : Type . b → b")
+		assert(identity.inferType().right?.description, ==, "λ a : Type . a → a")
 	}
 
 	func testProductDescription() {
@@ -34,12 +34,12 @@ final class TermTests: XCTestCase {
 	func testHigherOrderConstruction() {
 		assert(Term.lambda(.UnitType, id), ==, .Lambda(0, .UnitType, 0))
 		assert(identity, ==, .Lambda(1, .Type, .Lambda(0, 1, 0)))
-		assert(constant, ==, .Lambda(3, .Type, .Lambda(2, .Type, .Lambda(1, 3, .Lambda(0, 2, 1)))))
+		assert(constant, ==, .Lambda(2, .Type, .Lambda(1, .Type, .Lambda(0, 2, .Lambda(-1, 1, 0)))))
 	}
 
 	func testFunctionTypeConstruction() {
 		let expected = Term.lambda(.Type) { A in .lambda(.FunctionType(A, A), A, const(A)) }
-		let actual = Term.Lambda(2, .Type, .Lambda(1, .Lambda(-1, 2, 2), .Lambda(0, 2, 2)))
+		let actual = Term.Lambda(0, .Type, .Lambda(-1, .Lambda(-1, 0, 0), .Lambda(-1, 0, 0)))
 		assert(expected, ==, actual)
 	}
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -54,6 +54,10 @@ final class TermTests: XCTestCase {
 	func testLambdasDoNotShadowFreeVariablesInTheirTypes() {
 		assert(Term.Lambda(1, 1, 1).freeVariables, ==, [ 1 ])
 	}
+
+	func testLambdasBindVariablesDeeply() {
+		assert(Term.Lambda(2, .Type, .Lambda(1, 2, .Lambda(0, .UnitType, .Product(2, .Product(1, 0))))).freeVariables, ==, [])
+	}
 }
 
 

--- a/ManifoldTests/TypecheckingTests.swift
+++ b/ManifoldTests/TypecheckingTests.swift
@@ -24,7 +24,7 @@ final class TypecheckingTests: XCTestCase {
 	}
 
 	func testAbstractedAbstractionTypechecks() {
-		assert(identity.inferType(), ==, .Lambda(1, .Type, .Lambda(0, 1, 1)))
+		assert(identity.inferType(), ==, .Lambda(0, .Type, .Lambda(-1, 0, 0)))
 	}
 
 	func testProjectionTypechecksToTypeOfProjectedField() {


### PR DESCRIPTION
- [x] Constructs unambiguously non-dependent lambdas wherever possible.
- [x] Addresses some shared state issues around circular programming and, of course, state.
- [x] Improves the debugging of module typechecking failures by logging which specific declaration and data constructor is at fault.
- [x] Produces nicer lambdas by “flattening,” such that `λ b : Type .  λ _ : b . b` will instead be rendered as `λ a : Type . a → a`.
- [x] Corrects a subtle, long-standing issue where we were inferring _incidentally_ correct types, rather than _definitionally_ correct ones.
- [x] Improves debugging of unexpectedly free variables by pretty-printing them.
- [x] Fixes #103.
