### PR TITLE
Church-encoded booleans

### DIFF
--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		D4E9901C1BD3431D00F00CA7 /* Module+Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E9901B1BD3431D00F00CA7 /* Module+Either.swift */; settings = {ASSET_TAGS = (); }; };
 		D4E9901E1BD343AE00F00CA7 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E9901D1BD343AE00F00CA7 /* EitherTests.swift */; settings = {ASSET_TAGS = (); }; };
 		D4E990201BD347CF00F00CA7 /* Module+ChurchBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E9901F1BD347CF00F00CA7 /* Module+ChurchBoolean.swift */; settings = {ASSET_TAGS = (); }; };
+		D4E990221BD349EF00F00CA7 /* ChurchBooleanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E990211BD349EF00F00CA7 /* ChurchBooleanTests.swift */; settings = {ASSET_TAGS = (); }; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B84E1B46E2F40065BF22 /* Int.swift */; };
 		D4F1B8511B46EBE10065BF22 /* LazyScanSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B8501B46EBE10065BF22 /* LazyScanSequence.swift */; };
@@ -126,6 +127,7 @@
 		D4E9901B1BD3431D00F00CA7 /* Module+Either.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+Either.swift"; sourceTree = "<group>"; };
 		D4E9901D1BD343AE00F00CA7 /* EitherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
 		D4E9901F1BD347CF00F00CA7 /* Module+ChurchBoolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+ChurchBoolean.swift"; sourceTree = "<group>"; };
+		D4E990211BD349EF00F00CA7 /* ChurchBooleanTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChurchBooleanTests.swift; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4F1B84E1B46E2F40065BF22 /* Int.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		D4F1B8501B46EBE10065BF22 /* LazyScanSequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyScanSequence.swift; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 			children = (
 				D4E101B71B484606001A7E55 /* NaturalTests.swift */,
 				D4FB02DA1B71D1F10090E764 /* BooleanTests.swift */,
+				D4E990211BD349EF00F00CA7 /* ChurchBooleanTests.swift */,
 				D445417D1BCAB11100F2946D /* UnitTests.swift */,
 				D44541811BCAE3CD00F2946D /* ListTests.swift */,
 				D463F6D41BD2A91200BA0628 /* MaybeTests.swift */,
@@ -449,6 +452,7 @@
 				D4F1B8591B470E8E0065BF22 /* DoubleExtensionTests.swift in Sources */,
 				D4E9901E1BD343AE00F00CA7 /* EitherTests.swift in Sources */,
 				D4809FBD1AF6BD400084B8FE /* TermTests.swift in Sources */,
+				D4E990221BD349EF00F00CA7 /* ChurchBooleanTests.swift in Sources */,
 				D48404B81BC36F88006EABAC /* DatatypeTests.swift in Sources */,
 				D43AC8871BC1831F008762B7 /* TelescopeTests.swift in Sources */,
 				D44541821BCAE3CD00F2946D /* ListTests.swift in Sources */,

--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		D4E8291B1B521F1100713E60 /* LazyConcatSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8291A1B521F1100713E60 /* LazyConcatSequence.swift */; };
 		D4E9901C1BD3431D00F00CA7 /* Module+Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E9901B1BD3431D00F00CA7 /* Module+Either.swift */; settings = {ASSET_TAGS = (); }; };
 		D4E9901E1BD343AE00F00CA7 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E9901D1BD343AE00F00CA7 /* EitherTests.swift */; settings = {ASSET_TAGS = (); }; };
+		D4E990201BD347CF00F00CA7 /* Module+ChurchBoolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E9901F1BD347CF00F00CA7 /* Module+ChurchBoolean.swift */; settings = {ASSET_TAGS = (); }; };
 		D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EDEF561AFEDEC5001B9A1D /* Name.swift */; };
 		D4F1B84F1B46E2F40065BF22 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B84E1B46E2F40065BF22 /* Int.swift */; };
 		D4F1B8511B46EBE10065BF22 /* LazyScanSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F1B8501B46EBE10065BF22 /* LazyScanSequence.swift */; };
@@ -124,6 +125,7 @@
 		D4E8291A1B521F1100713E60 /* LazyConcatSequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyConcatSequence.swift; sourceTree = "<group>"; };
 		D4E9901B1BD3431D00F00CA7 /* Module+Either.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+Either.swift"; sourceTree = "<group>"; };
 		D4E9901D1BD343AE00F00CA7 /* EitherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
+		D4E9901F1BD347CF00F00CA7 /* Module+ChurchBoolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+ChurchBoolean.swift"; sourceTree = "<group>"; };
 		D4EDEF561AFEDEC5001B9A1D /* Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Name.swift; sourceTree = "<group>"; };
 		D4F1B84E1B46E2F40065BF22 /* Int.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Int.swift; sourceTree = "<group>"; };
 		D4F1B8501B46EBE10065BF22 /* LazyScanSequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyScanSequence.swift; sourceTree = "<group>"; };
@@ -285,6 +287,7 @@
 				D4E101B91B484611001A7E55 /* Module+Natural.swift */,
 				D463F6D11BD2A83E00BA0628 /* Module+Maybe.swift */,
 				D4E9901B1BD3431D00F00CA7 /* Module+Either.swift */,
+				D4E9901F1BD347CF00F00CA7 /* Module+ChurchBoolean.swift */,
 			);
 			name = Modules;
 			sourceTree = "<group>";
@@ -414,6 +417,7 @@
 				D4B56CB11AFDA26A00D7BD6F /* Expression.swift in Sources */,
 				D4B4AA571A90320F0089A5F2 /* Dictionary.swift in Sources */,
 				D4E8289D1B5202BB00713E60 /* StringLiteralConvertible.swift in Sources */,
+				D4E990201BD347CF00F00CA7 /* Module+ChurchBoolean.swift in Sources */,
 				D4EDEF571AFEDEC5001B9A1D /* Name.swift in Sources */,
 				D4A31B2A1AA366EC00B3FC68 /* TermType.swift in Sources */,
 				D44541801BCAC38500F2946D /* Module+List.swift in Sources */,

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -30,7 +30,11 @@ extension Module {
 			type: Recur.FunctionType(Boolean.ref, Boolean.ref, Boolean.ref),
 			value: Recur.lambda(Boolean.ref, Boolean.ref) { p, q in p[Boolean.ref, `true`.ref, q] })
 
-		return Module([ Boolean, `true`, `false`, not, `if`, and, or ])
+		let xor = Declaration("xor",
+			type: Recur.FunctionType(Boolean.ref, Boolean.ref, Boolean.ref),
+			value: Recur.lambda(Boolean.ref, Boolean.ref, { p, q in p[Boolean.ref, not.ref[q], q] }))
+
+		return Module([ Boolean, `true`, `false`, not, `if`, and, or, xor ])
 	}
 }
 

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -14,7 +14,11 @@ extension Module {
 			type: Boolean.ref,
 			value: Recur.lambda(.Type) { A in Recur.lambda(A, A, { _, b in b }) })
 
-		return Module([ Boolean, `true`, `false` ])
+		let not = Declaration("not",
+			type: Recur.FunctionType(Boolean.ref, Boolean.ref),
+			value: Recur.lambda(Boolean.ref, .Type) { b, A in Recur.lambda(A, A) { t, f in b[A, f, t] } })
+
+		return Module([ Boolean, `true`, `false`, not ])
 	}
 }
 

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -20,7 +20,7 @@ extension Module {
 
 		let `if` = Declaration("if",
 			type: Recur.lambda(.Type, Boolean.ref) { A, condition in Recur.lambda(A, A, const(A)) },
-			value: Recur.lambda(.Type, Boolean.ref) { A, condition in Recur.lambda(A, A) { condition[$0, $1] } })
+			value: Recur.lambda(.Type, Boolean.ref) { A, condition in Recur.lambda(A, A) { condition[A, $0, $1] } })
 
 		let and = Declaration("and",
 			type: Recur.FunctionType(Boolean.ref, Boolean.ref, Boolean.ref),

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -6,7 +6,11 @@ extension Module {
 			type: .Type,
 			value: Recur.lambda(.Type) { Recur.lambda($0, $0, const($0)) })
 
-		return Module([ Boolean ])
+		let `true` = Declaration("true",
+			type: Boolean.ref,
+			value: Recur.lambda(.Type) { A in Recur.lambda(A, A, { a, _ in a }) })
+
+		return Module([ Boolean, `true` ])
 	}
 }
 

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -1,0 +1,7 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension Module {
+	public static var churchBoolean: Module {
+		return Module([])
+	}
+}

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -26,7 +26,11 @@ extension Module {
 			type: Recur.FunctionType(Boolean.ref, Boolean.ref, Boolean.ref),
 			value: Recur.lambda(Boolean.ref, Boolean.ref) { p, q in p[Boolean.ref, q, `false`.ref] })
 
-		return Module([ Boolean, `true`, `false`, not, `if`, and ])
+		let or = Declaration("or",
+			type: Recur.FunctionType(Boolean.ref, Boolean.ref, Boolean.ref),
+			value: Recur.lambda(Boolean.ref, Boolean.ref) { p, q in p[Boolean.ref, `true`.ref, q] })
+
+		return Module([ Boolean, `true`, `false`, not, `if`, and, or ])
 	}
 }
 

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -22,7 +22,11 @@ extension Module {
 			type: Recur.lambda(.Type, Boolean.ref) { A, condition in Recur.lambda(A, A, const(A)) },
 			value: Recur.lambda(.Type, Boolean.ref) { A, condition in Recur.lambda(A, A) { condition[$0, $1] } })
 
-		return Module([ Boolean, `true`, `false`, not, `if` ])
+		let and = Declaration("and",
+			type: Recur.FunctionType(Boolean.ref, Boolean.ref, Boolean.ref),
+			value: Recur.lambda(Boolean.ref, Boolean.ref) { p, q in p[Boolean.ref, q, `false`.ref] })
+
+		return Module([ Boolean, `true`, `false`, not, `if`, and ])
 	}
 }
 

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -10,7 +10,11 @@ extension Module {
 			type: Boolean.ref,
 			value: Recur.lambda(.Type) { A in Recur.lambda(A, A, { a, _ in a }) })
 
-		return Module([ Boolean, `true` ])
+		let `false` = Declaration("false",
+			type: Boolean.ref,
+			value: Recur.lambda(.Type) { A in Recur.lambda(A, A, { _, b in b }) })
+
+		return Module([ Boolean, `true`, `false` ])
 	}
 }
 

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -8,11 +8,11 @@ extension Module {
 
 		let `true` = Declaration("true",
 			type: Boolean.ref,
-			value: Recur.lambda(.Type) { A in Recur.lambda(A, A, { a, _ in a }) })
+			value: Recur.lambda(.Type) { A in Recur.lambda(A, A) { a, _ in a } })
 
 		let `false` = Declaration("false",
 			type: Boolean.ref,
-			value: Recur.lambda(.Type) { A in Recur.lambda(A, A, { _, b in b }) })
+			value: Recur.lambda(.Type) { A in Recur.lambda(A, A) { _, b in b } })
 
 		let not = Declaration("not",
 			type: Recur.FunctionType(Boolean.ref, Boolean.ref),

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -18,7 +18,11 @@ extension Module {
 			type: Recur.FunctionType(Boolean.ref, Boolean.ref),
 			value: Recur.lambda(Boolean.ref, .Type) { b, A in Recur.lambda(A, A) { t, f in b[A, f, t] } })
 
-		return Module([ Boolean, `true`, `false`, not ])
+		let `if` = Declaration("if",
+			type: Recur.lambda(.Type, Boolean.ref) { A, condition in Recur.lambda(A, A, const(A)) },
+			value: Recur.lambda(.Type, Boolean.ref) { A, condition in Recur.lambda(A, A) { condition[$0, $1] } })
+
+		return Module([ Boolean, `true`, `false`, not, `if` ])
 	}
 }
 

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -2,6 +2,13 @@
 
 extension Module {
 	public static var churchBoolean: Module {
-		return Module([])
+		let Boolean = Declaration("Boolean",
+			type: .Type,
+			value: Recur.lambda(.Type) { Recur.lambda($0, $0, const($0)) })
+
+		return Module([ Boolean ])
 	}
 }
+
+
+import Prelude

--- a/Manifold/TermType+Checking.swift
+++ b/Manifold/TermType+Checking.swift
@@ -56,11 +56,11 @@ extension TermType {
 		}
 	}
 
-	static func toString(context: [Name:Self]) -> String {
-		let keys = context.keys.sort().lazy
+	static func toString(table: [Name:Self]) -> String {
+		let keys = table.keys.sort().lazy
 		let maxLength: Int = keys.maxElement { $0.description.characters.count < $1.description.characters.count }?.description.characters.count ?? 0
 		let padding: Character = " "
-		let formattedContext = keys.map { "\(String(Self.describe($0), paddedTo: maxLength, with: padding)) : \(context[$0]!)" }.joinWithSeparator(",\n\t")
+		let formattedContext = keys.map { "\(String(Self.describe($0), paddedTo: maxLength, with: padding)) : \(table[$0]!)" }.joinWithSeparator(",\n\t")
 
 		return "[\n\t\(formattedContext)\n]"
 	}

--- a/Manifold/TermType+Checking.swift
+++ b/Manifold/TermType+Checking.swift
@@ -68,7 +68,7 @@ extension TermType {
 		let keys = table.keys.sort().lazy
 		let maxLength: Int = keys.maxElement { $0.description.characters.count < $1.description.characters.count }?.description.characters.count ?? 0
 		let padding: Character = " "
-		let formattedContext = keys.map { "\(String(Self.describe($0), paddedTo: maxLength, with: padding)) : \(table[$0]!)" }.joinWithSeparator(",\n\t")
+		let formattedContext = keys.map { "\(String(Self.describe($0), paddedTo: maxLength, with: padding)) \(separator) \(table[$0]!)" }.joinWithSeparator(",\n\t")
 
 		return "[\n\t\(formattedContext)\n]"
 	}

--- a/Manifold/TermType+Checking.swift
+++ b/Manifold/TermType+Checking.swift
@@ -51,12 +51,20 @@ extension TermType {
 				.flatMap { inferred in
 					Self.alphaEquivalent(inferred, against, environment)
 						? Either.Right(inferred)
-						: Either.Left("Type mismatch: expected '\(self)' to be of type '\(against)', but it was actually of type '\(inferred)' in context: \(Self.toString(context)), environment: \(Self.toString(environment))")
+						: Either.Left("Type mismatch: expected '\(self)' to be of type '\(against)', but it was actually of type '\(inferred)' in context: \(Self.toString(context: context)), environment: \(Self.toString(environment: environment))")
 			}
 		}
 	}
 
-	static func toString(table: [Name:Self]) -> String {
+	static func toString(context context: [Name:Self]) -> String {
+		return toString(context, separator: ":")
+	}
+
+	static func toString(environment environment: [Name:Self]) -> String {
+		return toString(environment, separator: "=")
+	}
+
+	static func toString(table: [Name:Self], separator: String) -> String {
 		let keys = table.keys.sort().lazy
 		let maxLength: Int = keys.maxElement { $0.description.characters.count < $1.description.characters.count }?.description.characters.count ?? 0
 		let padding: Character = " "

--- a/Manifold/TermType+Construction.swift
+++ b/Manifold/TermType+Construction.swift
@@ -152,7 +152,7 @@ extension TermType {
 		return cata {
 			$0.analysis(
 				ifApplication: max,
-				ifLambda: { max($0.0, $0.1) },
+				ifLambda: { $0 < 0 ? max($1, $2) : max($0, $1) },
 				ifProjection: { $0.0 },
 				ifProduct: max,
 				ifIf: { max($0, $1, $2) },

--- a/Manifold/TermType+Inference.swift
+++ b/Manifold/TermType+Inference.swift
@@ -27,7 +27,7 @@ extension TermType {
 			return .right(.Type(n + 1))
 
 		case let .Variable(i):
-			return context[i].map(Either.Right) ?? Either.Left("Unexpectedly free variable \(Self.describe(i)) in context: \(Self.toString(context)), environment: \(Self.toString(environment))")
+			return context[i].map(Either.Right) ?? Either.Left("Unexpectedly free variable \(Self.describe(i)) in context: \(Self.toString(context: context)), environment: \(Self.toString(environment: environment))")
 
 		case let .Lambda(i, type, body):
 			return type.checkIsType(environment, context)
@@ -46,7 +46,7 @@ extension TermType {
 							b.checkType(type, environment, context)
 								.map { _ in body.substitute(i, b) }
 						},
-						otherwise: const(Either.Left("Illegal application of \(a) : \(A) to \(b) in context: \(Self.toString(context)), environment: \(Self.toString(environment))")))
+						otherwise: const(Either.Left("Illegal application of \(a) : \(A) to \(b) in context: \(Self.toString(context: context)), environment: \(Self.toString(environment: environment))")))
 			}
 
 		case let .Projection(term, branch):
@@ -56,7 +56,7 @@ extension TermType {
 						ifLambda: { i, A, B in
 							Either.Right(branch ? B.substitute(i, A) : A)
 						},
-						otherwise: const(Either.Left("Illegal projection of field \(branch ? 1 : 0) of non-product value \(term) of type \(type) in context: \(Self.toString(context)), environment: \(Self.toString(environment))")))
+						otherwise: const(Either.Left("Illegal projection of field \(branch ? 1 : 0) of non-product value \(term) of type \(type) in context: \(Self.toString(context: context)), environment: \(Self.toString(environment: environment))")))
 			}
 
 		case let .Annotation(term, type):

--- a/ManifoldTests/ChurchBooleanTests.swift
+++ b/ManifoldTests/ChurchBooleanTests.swift
@@ -4,10 +4,16 @@ final class ChurchBooleanTests: XCTestCase {
 	func testModuleTypechecks() {
 		module.typecheck().forEach { XCTFail($0.description) }
 	}
+
+	func testTrueReturnsItsFirstTermArgument() {
+		assert(`true`[.Type, .Boolean(true), .Boolean(false)].evaluate(module.environment), ==, true)
+	}
 }
 
 private let module = Module<Term>.churchBoolean
+private let `true`: Term = "true"
 
 
+import Assertions
 import Manifold
 import XCTest

--- a/ManifoldTests/ChurchBooleanTests.swift
+++ b/ManifoldTests/ChurchBooleanTests.swift
@@ -8,10 +8,15 @@ final class ChurchBooleanTests: XCTestCase {
 	func testTrueReturnsItsFirstTermArgument() {
 		assert(`true`[.Type, .Boolean(true), .Boolean(false)].evaluate(module.environment), ==, true)
 	}
+
+	func testFalseReturnsItsSecondTermArgument() {
+		assert(`false`[.Type, .Boolean(true), .Boolean(false)].evaluate(module.environment), ==, false)
+	}
 }
 
 private let module = Module<Term>.churchBoolean
 private let `true`: Term = "true"
+private let `false`: Term = "false"
 
 
 import Assertions

--- a/ManifoldTests/ChurchBooleanTests.swift
+++ b/ManifoldTests/ChurchBooleanTests.swift
@@ -1,0 +1,13 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+final class ChurchBooleanTests: XCTestCase {
+	func testModuleTypechecks() {
+		module.typecheck().forEach { XCTFail($0.description) }
+	}
+}
+
+private let module = Module<Term>.churchBoolean
+
+
+import Manifold
+import XCTest

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -37,6 +37,11 @@ final class TermTests: XCTestCase {
 		assert(constant, ==, .Lambda(2, .Type, .Lambda(1, .Type, .Lambda(0, 2, .Lambda(-1, 1, 0)))))
 	}
 
+	func testChurchEncodedBooleanConstruction() {
+		assert(Term.lambda(.Type) { A in Term.lambda(A, A) { a, _ in a } }, ==, Term.Lambda(1, .Type, .Lambda(0, 1, .Lambda(-1, 1, 0))))
+		assert(Term.lambda(.Type) { A in Term.lambda(A, A) { _, b in b } }, ==, Term.Lambda(1, .Type, .Lambda(-1, 1, .Lambda(0, 1, 0))))
+	}
+
 	func testFunctionTypeConstruction() {
 		let expected = Term.lambda(.Type) { A in .lambda(.FunctionType(A, A), A, const(A)) }
 		let actual = Term.Lambda(0, .Type, .Lambda(-1, .Lambda(-1, 0, 0), .Lambda(-1, 0, 0)))

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -38,8 +38,8 @@ final class TermTests: XCTestCase {
 	}
 
 	func testChurchEncodedBooleanConstruction() {
-		assert(Term.lambda(.Type) { A in Term.lambda(A, A) { a, _ in a } }, ==, Term.Lambda(1, .Type, .Lambda(0, 1, .Lambda(-1, 1, 0))))
-		assert(Term.lambda(.Type) { A in Term.lambda(A, A) { _, b in b } }, ==, Term.Lambda(1, .Type, .Lambda(-1, 1, .Lambda(0, 1, 0))))
+		assert(Term.lambda(.Type) { A in Term.lambda(A, A) { a, _ in a } }, ==, .Lambda(1, .Type, .Lambda(0, 1, .Lambda(-1, 1, 0))))
+		assert(Term.lambda(.Type) { A in Term.lambda(A, A) { _, b in b } }, ==, .Lambda(1, .Type, .Lambda(-1, 1, .Lambda(0, 1, 0))))
 	}
 
 	func testFunctionTypeConstruction() {

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -43,9 +43,7 @@ final class TermTests: XCTestCase {
 	}
 
 	func testFunctionTypeConstruction() {
-		let expected = Term.lambda(.Type) { A in .lambda(.FunctionType(A, A), A, const(A)) }
-		let actual = Term.Lambda(0, .Type, .Lambda(-1, .Lambda(-1, 0, 0), .Lambda(-1, 0, 0)))
-		assert(expected, ==, actual)
+		assert(Term.lambda(.Type) { A in .lambda(.FunctionType(A, A), A, const(A)) }, ==, .Lambda(0, .Type, .Lambda(-1, .Lambda(-1, 0, 0), .Lambda(-1, 0, 0))))
 	}
 
 	func testSubstitution() {


### PR DESCRIPTION
- [x] Adds Church-encoded booleans in a module of their own.
- [x] Pretty-prints entries in environments as `$name = $value` instead of `$name : $value`.
- [x] Fixes an issue where lambdas whose parameter is used wrapping a lambda whose parameter is unused wrapping a lambda whose parameter is used would be constructed with the wrong variable on the outermost lambda.
