### PR TITLE
Better annotations

### DIFF
--- a/Manifold/Declaration.swift
+++ b/Manifold/Declaration.swift
@@ -78,8 +78,7 @@ extension Declaration where Recur: TermType {
 			return value.checkType(type, environment, context).left.map { [ $0.map { "\(symbol): \($0)" } ] } ?? []
 		case let .Datatype(symbol, _):
 			return definitions
-				.flatMap { symbol, type, value in value.checkType(type, environment, context).left.map { $0.map { "\(symbol): \($0)" } } }
-				.map { $0.map { "\(symbol): \($0)" } }
+				.flatMap { definition, type, value in value.checkType(type, environment, context).left.map { $0.map { "\(symbol).\(definition): \($0)" } } }
 		}
 	}
 }

--- a/Manifold/Declaration.swift
+++ b/Manifold/Declaration.swift
@@ -73,10 +73,14 @@ extension Declaration where Recur: TermType {
 	}
 
 	public func typecheck(environment: [Name:Recur], _ context: [Name:Recur]) -> [Error] {
-		let symbol = self.symbol
-		return definitions
-			.flatMap { symbol, type, value in value.checkType(type, environment, context).left.map { $0.map { "\(symbol): \($0)" } } }
-			.map { $0.map { "\(symbol): \($0)" } }
+		switch self {
+		case let .Definition(symbol, type, value):
+			return value.checkType(type, environment, context).left.map { [ $0.map { "\(symbol): \($0)" } ] } ?? []
+		case let .Datatype(symbol, _):
+			return definitions
+				.flatMap { symbol, type, value in value.checkType(type, environment, context).left.map { $0.map { "\(symbol): \($0)" } } }
+				.map { $0.map { "\(symbol): \($0)" } }
+		}
 	}
 }
 

--- a/Manifold/Module+Boolean.swift
+++ b/Manifold/Module+Boolean.swift
@@ -2,7 +2,7 @@
 
 extension Module {
 	public static var boolean: Module {
-		return Module([
+		return Module("Boolean", [
 			.Datatype("Boolean", [
 				"true": .End,
 				"false": .End

--- a/Manifold/Module+ChurchBoolean.swift
+++ b/Manifold/Module+ChurchBoolean.swift
@@ -34,7 +34,7 @@ extension Module {
 			type: Recur.FunctionType(Boolean.ref, Boolean.ref, Boolean.ref),
 			value: Recur.lambda(Boolean.ref, Boolean.ref, { p, q in p[Boolean.ref, not.ref[q], q] }))
 
-		return Module([ Boolean, `true`, `false`, not, `if`, and, or, xor ])
+		return Module("ChurchBoolean", [ Boolean, `true`, `false`, not, `if`, and, or, xor ])
 	}
 }
 

--- a/Manifold/Module+Either.swift
+++ b/Manifold/Module+Either.swift
@@ -2,7 +2,7 @@
 
 extension Module {
 	public static var either: Module {
-		return Module([
+		return Module("Either", [
 			Declaration("Either", .Type, .Type) {
 				[
 					"left": .Argument($0, const(.End)),

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -2,7 +2,7 @@
 
 extension Module {
 	public static var list: Module {
-		return Module([
+		return Module("List", [
 			Declaration.Datatype("List", .Argument(.Type, {
 				[
 					"nil": .End,

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -2,7 +2,7 @@
 
 extension Module {
 	public static var maybe: Module {
-		return Module([
+		return Module("Maybe", [
 			Declaration.Datatype("Maybe", .Argument(.Type, {
 				[
 					"just": .Argument($0, const(.End)),

--- a/Manifold/Module+Natural.swift
+++ b/Manifold/Module+Natural.swift
@@ -2,7 +2,7 @@
 
 extension Module {
 	public static var natural: Module {
-		return Module([
+		return Module("Natural", [
 			.Datatype("Natural", [
 				"zero": .End,
 				"successor": .Recursive(.End)

--- a/Manifold/Module+Unit.swift
+++ b/Manifold/Module+Unit.swift
@@ -2,7 +2,7 @@
 
 extension Module {
 	public static var unit: Module {
-		return Module([
+		return Module("Unit", [
 			.Datatype("Unit", [ "unit": .End ]),
 		])
 	}

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -52,7 +52,7 @@ extension Module where Recur: TermType {
 		let context = self.context
 		return declarations
 			.lazy
-			.flatMap { $0.typecheck(environment, context) }
+			.flatMap { $0.typecheck(environment, context).map { $0.map { "\(self.name): \($0)" } } }
 	}
 }
 

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -4,14 +4,17 @@ public struct Module<Recur: TermType> {
 	public typealias Environment = [Name:Recur]
 	public typealias Context = [Name:Recur]
 
-	public init<D: SequenceType, S: SequenceType where D.Generator.Element == Module, S.Generator.Element == Declaration<Recur>>(_ dependencies: D, _ declarations: S) {
+	public init<D: SequenceType, S: SequenceType where D.Generator.Element == Module, S.Generator.Element == Declaration<Recur>>(_ name: String, _ dependencies: D, _ declarations: S) {
+		self.name = name
 		self.dependencies = Array(dependencies)
 		self.declarations = Array(declarations)
 	}
 
-	public init<S: SequenceType where S.Generator.Element == Declaration<Recur>>(_ declarations: S) {
-		self.init([], declarations)
+	public init<S: SequenceType where S.Generator.Element == Declaration<Recur>>(_ name: String, _ declarations: S) {
+		self.init(name, [], declarations)
 	}
+
+	public let name: String
 
 	public let dependencies: [Module]
 	public let declarations: [Declaration<Recur>]

--- a/ManifoldTests/DeclarationTests.swift
+++ b/ManifoldTests/DeclarationTests.swift
@@ -59,7 +59,7 @@ final class DeclarationTests: XCTestCase {
 }
 
 
-private let selfModule = Module<Term>([], [
+private let selfModule = Module<Term>("Self", [], [
 	Declaration.Datatype("Self", [
 		"me": .End,
 		"myself": .End,
@@ -67,13 +67,13 @@ private let selfModule = Module<Term>([], [
 	])
 ])
 
-private let oneConstructorWithArgumentModule = Module<Term>([], [
+private let oneConstructorWithArgumentModule = Module<Term>("A", [], [
 	Declaration.Datatype("A", [
 		"a": .Argument(.BooleanType, const(.End)),
 	])
 ])
 
-private let multipleConstructorsWithArgumentsModule = Module<Term>([], [
+private let multipleConstructorsWithArgumentsModule = Module<Term>("A", [], [
 	Declaration.Datatype("A", [
 		"a": .Argument(.BooleanType, const(.End)),
 		"b": .Argument(.BooleanType, const(.End)),
@@ -81,7 +81,7 @@ private let multipleConstructorsWithArgumentsModule = Module<Term>([], [
 	])
 ])
 
-private let multipleConstructorsWithMultipleArgumentsModule = Module<Term>([], [
+private let multipleConstructorsWithMultipleArgumentsModule = Module<Term>("A", [], [
 	Declaration.Datatype("A", [
 		"a": Telescope.Argument(.BooleanType) { a in .Argument(.BooleanType, const(.End)) },
 		"b": Telescope.Argument(.BooleanType) { a in .Argument(.BooleanType, const(.End)) },


### PR DESCRIPTION
Annotate declaration typechecking errors with the appropriate symbol. For normal declarations this is just the definition being typechecked, while for datatypes this annotation will be of the form `TypeName.definitionName`.

In both cases the error is then prefixed with `ModuleName:`.
