### PR TITLE
Type is no longer in Type.

### DIFF
--- a/Manifold/TermType+Elaboration.swift
+++ b/Manifold/TermType+Elaboration.swift
@@ -28,7 +28,7 @@ extension TermType {
 				let bʹ = try b.elaborateType(nil, environment, context + [ .Local(i): a ])
 				return .Unroll(a => { bʹ.type.substitute(i, $0) }, .Lambda(i, aʹ, bʹ))
 
-			case (.Type, .Some(.Type)):
+			case let (.Type(m), .Some(.Type(n))) where n > m:
 				return try elaborateType(nil, environment, context)
 
 			case let (.Lambda(i, type1, body), .Some(.Lambda(j, type2, bodyType))) where Self.equate(type1, type2, environment):


### PR DESCRIPTION
Instead, Type m is in every Type n such that n > m.

Apparently we didn’t depend on Type : Type anywhere.

Fixes #42.
