### PR TITLE
Optional type annotations in lambdas

### DIFF
--- a/Manifold/Declaration.swift
+++ b/Manifold/Declaration.swift
@@ -5,6 +5,18 @@ public enum Declaration: CustomStringConvertible {
 		self = .Definition(symbol, type, value)
 	}
 
+	public init(_ symbol: Name, type: Term, value: Term -> Term) {
+		self = .Definition(symbol, type, nil => value)
+	}
+
+	public init(_ symbol: Name, type: Term, value: (Term, Term) -> Term) {
+		self = .Definition(symbol, type, (nil, nil) => value)
+	}
+
+	public init(_ symbol: Name, type: Term, value: (Term, Term, Term) -> Term) {
+		self = .Definition(symbol, type, (nil, nil, nil) => value)
+	}
+
 	public init(_ symbol: Name, _ datatype: Manifold.Datatype) {
 		self = .Datatype(symbol, datatype)
 	}

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -12,7 +12,7 @@ public enum Expression<Recur> {
 		case let .Application(a, b):
 			return try .Application(transform(a), transform(b))
 		case let .Lambda(i, a, b):
-			return try .Lambda(i, transform(a), transform(b))
+			return try .Lambda(i, a.map(transform), transform(b))
 		}
 	}
 
@@ -22,7 +22,7 @@ public enum Expression<Recur> {
 	case Type(Int)
 	case Variable(Name)
 	case Application(Recur, Recur)
-	case Lambda(Int, Recur, Recur) // (Πx:A)B where B can depend on x
+	case Lambda(Int, Recur?, Recur) // (Πx:A)B where B can depend on x
 }
 
 

--- a/Manifold/Module+Boolean.swift
+++ b/Manifold/Module+Boolean.swift
@@ -12,23 +12,23 @@ extension Module {
 
 		let not = Declaration("not",
 			type: Boolean.ref --> Boolean.ref,
-			value: (Boolean.ref, .Type) => { b, A in (A, A) => { t, f in b[A, f, t] } })
+			value: (nil, nil) => { b, A in (nil, nil) => { t, f in b[A, f, t] } })
 
 		let `if` = Declaration("if",
 			type: (.Type, Boolean.ref) => { A, condition in (A, A) => const(A) },
-			value: (.Type, Boolean.ref) => { A, condition in (A, A) => { condition[A, $0, $1] } })
+			value: (nil, nil) => { A, condition in (nil, nil) => { condition[A, $0, $1] } })
 
 		let and = Declaration("and",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: (Boolean.ref, Boolean.ref) => { p, q in p[Boolean.ref, q, `false`] })
+			value: (nil, nil) => { p, q in p[Boolean.ref, q, `false`] })
 
 		let or = Declaration("or",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: (Boolean.ref, Boolean.ref) => { p, q in p[Boolean.ref, `true`, q] })
+			value: (nil, nil) => { p, q in p[Boolean.ref, `true`, q] })
 
 		let xor = Declaration("xor",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: (Boolean.ref, Boolean.ref) => { p, q in p[Boolean.ref, not.ref[q], q] })
+			value: (nil, nil) => { p, q in p[Boolean.ref, not.ref[q], q] })
 
 		return Module("Boolean", [ Boolean, not, `if`, and, or, xor ])
 	}

--- a/Manifold/Module+Boolean.swift
+++ b/Manifold/Module+Boolean.swift
@@ -12,11 +12,11 @@ extension Module {
 
 		let not = Declaration("not",
 			type: Boolean.ref --> Boolean.ref,
-			value: { b, A in (nil, nil) => { t, f in b[A, f, t] } })
+			value: { b, A in () => { t, f in b[A, f, t] } })
 
 		let `if` = Declaration("if",
 			type: (.Type, Boolean.ref) => { A, condition in (A, A) => const(A) },
-			value: { A, condition in (nil, nil) => { condition[A, $0, $1] } })
+			value: { A, condition in () => { condition[A, $0, $1] } })
 
 		let and = Declaration("and",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,

--- a/Manifold/Module+Boolean.swift
+++ b/Manifold/Module+Boolean.swift
@@ -12,23 +12,23 @@ extension Module {
 
 		let not = Declaration("not",
 			type: Boolean.ref --> Boolean.ref,
-			value: (nil, nil) => { b, A in (nil, nil) => { t, f in b[A, f, t] } })
+			value: { b, A in (nil, nil) => { t, f in b[A, f, t] } })
 
 		let `if` = Declaration("if",
 			type: (.Type, Boolean.ref) => { A, condition in (A, A) => const(A) },
-			value: (nil, nil) => { A, condition in (nil, nil) => { condition[A, $0, $1] } })
+			value: { A, condition in (nil, nil) => { condition[A, $0, $1] } })
 
 		let and = Declaration("and",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: (nil, nil) => { p, q in p[Boolean.ref, q, `false`] })
+			value: { p, q in p[Boolean.ref, q, `false`] })
 
 		let or = Declaration("or",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: (nil, nil) => { p, q in p[Boolean.ref, `true`, q] })
+			value: { p, q in p[Boolean.ref, `true`, q] })
 
 		let xor = Declaration("xor",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: (nil, nil) => { p, q in p[Boolean.ref, not.ref[q], q] })
+			value: { p, q in p[Boolean.ref, not.ref[q], q] })
 
 		return Module("Boolean", [ Boolean, not, `if`, and, or, xor ])
 	}

--- a/Manifold/Module+FiniteSet.swift
+++ b/Manifold/Module+FiniteSet.swift
@@ -6,16 +6,16 @@ extension Module {
 		let FiniteSet: Term = "FiniteSet"
 		let finiteSet = Declaration("FiniteSet",
 			type: Natural --> .Type,
-			value: nil => { n in n[.Type, .Type => { $0 --> $0 }, (Natural, .Type) => { n, A in A --> (FiniteSet[n] --> A) --> A }] })
+			value: { n in n[.Type, .Type => { $0 --> $0 }, (Natural, .Type) => { n, A in A --> (FiniteSet[n] --> A) --> A }] })
 
 		let successor: Term = "successor"
 		let zeroth = Declaration("zeroth",
 			type: Natural => { n in FiniteSet[successor[n]] },
-			value: nil => { n in nil => { A in nil => { (FiniteSet[n] --> A) --> $0 } } })
+			value: { n in nil => { A in nil => { (FiniteSet[n] --> A) --> $0 } } })
 
 		let nextth = Declaration("nextth",
 			type: Natural => { n in FiniteSet[n] --> FiniteSet[successor[n]] },
-			value: nil => { n in (FiniteSet[n], nil) => { prev, A in A --> nil => { $0[prev] } } })
+			value: { n in (FiniteSet[n], nil) => { prev, A in A --> nil => { $0[prev] } } })
 
 		return Module("FiniteSet", [ natural ], [ finiteSet, zeroth, nextth ])
 	}

--- a/Manifold/Module+FiniteSet.swift
+++ b/Manifold/Module+FiniteSet.swift
@@ -11,11 +11,11 @@ extension Module {
 		let successor: Term = "successor"
 		let zeroth = Declaration("zeroth",
 			type: Natural => { n in FiniteSet[successor[n]] },
-			value: { n in nil => { A in nil => { (FiniteSet[n] --> A) --> $0 } } })
+			value: { n in () => { A in () => { (FiniteSet[n] --> A) --> $0 } } })
 
 		let nextth = Declaration("nextth",
 			type: Natural => { n in FiniteSet[n] --> FiniteSet[successor[n]] },
-			value: { n in (FiniteSet[n], nil) => { prev, A in A --> nil => { $0[prev] } } })
+			value: { n in (FiniteSet[n], nil) => { prev, A in A --> () => { $0[prev] } } })
 
 		return Module("FiniteSet", [ natural ], [ finiteSet, zeroth, nextth ])
 	}

--- a/Manifold/Module+FiniteSet.swift
+++ b/Manifold/Module+FiniteSet.swift
@@ -6,16 +6,16 @@ extension Module {
 		let FiniteSet: Term = "FiniteSet"
 		let finiteSet = Declaration("FiniteSet",
 			type: Natural --> .Type,
-			value: Natural => { n in n[.Type, .Type => { $0 --> $0 }, (Natural, .Type) => { (n: Term, A) in A --> (FiniteSet[n] --> A) --> A }] })
+			value: nil => { n in n[.Type, .Type => { $0 --> $0 }, (Natural, .Type) => { n, A in A --> (FiniteSet[n] --> A) --> A }] })
 
 		let successor: Term = "successor"
 		let zeroth = Declaration("zeroth",
-			type: Natural => { (n: Term) in FiniteSet[successor[n]] },
-			value: Natural => { (n: Term) in .Type => { (A: Term) in A => { (FiniteSet[n] --> A) --> $0 } } })
+			type: Natural => { n in FiniteSet[successor[n]] },
+			value: nil => { n in nil => { A in nil => { (FiniteSet[n] --> A) --> $0 } } })
 
 		let nextth = Declaration("nextth",
-			type: Natural => { (n: Term) in FiniteSet[n] --> FiniteSet[successor[n]] },
-			value: Natural => { (n: Term) in (FiniteSet[n], .Type) => { (prev: Term, A) in A --> (FiniteSet[n] --> A) => { $0[prev] } } })
+			type: Natural => { n in FiniteSet[n] --> FiniteSet[successor[n]] },
+			value: nil => { n in (FiniteSet[n], nil) => { prev, A in A --> nil => { $0[prev] } } })
 
 		return Module("FiniteSet", [ natural ], [ finiteSet, zeroth, nextth ])
 	}

--- a/Manifold/Module+Pair.swift
+++ b/Manifold/Module+Pair.swift
@@ -8,11 +8,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> A },
-			value: { A, B in nil => { pair in pair[A, (nil, B) => { a, _ in a }] } })
+			value: { A, B in () => { pair in pair[A, (nil, B) => { a, _ in a }] } })
 
 		let second = Declaration("second",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> B },
-			value: { A, B in nil => { pair in pair[B, (nil, nil) => { _, b in b }] } })
+			value: { A, B in () => { pair in pair[B, () => { _, b in b }] } })
 
 		return Module("Pair", [ Pair, first, second ])
 	}

--- a/Manifold/Module+Pair.swift
+++ b/Manifold/Module+Pair.swift
@@ -8,11 +8,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> A },
-			value: (.Type, .Type) => { A, B in (Pair.ref[A, B]) => { pair in pair[A, (A, B) => { a, _ in a }] } })
+			value: (nil, nil) => { A, B in nil => { pair in pair[A, (nil, B) => { a, _ in a }] } })
 
 		let second = Declaration("second",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> B },
-			value: (.Type, .Type) => { A, B in (Pair.ref[A, B]) => { pair in pair[B, (A, B) => { _, b in b }] } })
+			value: (nil, nil) => { A, B in nil => { pair in pair[B, (nil, nil) => { _, b in b }] } })
 
 		return Module("Pair", [ Pair, first, second ])
 	}

--- a/Manifold/Module+Pair.swift
+++ b/Manifold/Module+Pair.swift
@@ -8,11 +8,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> A },
-			value: (nil, nil) => { A, B in nil => { pair in pair[A, (nil, B) => { a, _ in a }] } })
+			value: { A, B in nil => { pair in pair[A, (nil, B) => { a, _ in a }] } })
 
 		let second = Declaration("second",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> B },
-			value: (nil, nil) => { A, B in nil => { pair in pair[B, (nil, nil) => { _, b in b }] } })
+			value: { A, B in nil => { pair in pair[B, (nil, nil) => { _, b in b }] } })
 
 		return Module("Pair", [ Pair, first, second ])
 	}

--- a/Manifold/Module+Prelude.swift
+++ b/Manifold/Module+Prelude.swift
@@ -4,15 +4,15 @@ extension Module {
 	public static var prelude: Module {
 		let identity = Declaration("identity",
 			type: .Type => { A in A --> A },
-			value: nil => { A in A => id })
+			value: { A in A => id })
 
 		let constant = Declaration("constant",
 			type: (.Type, .Type) => { A, B in A --> B --> A },
-			value: (nil, nil) => { A, B in A => { B => const($0) } })
+			value: { A, B in A => { B => const($0) } })
 
 		let flip = Declaration("flip",
 			type: (.Type, .Type, .Type) => { A, B, C in (A --> B --> C) --> (B --> A --> C) },
-			value: (nil, nil, nil) => { A, B, C in (A --> B --> C) => { f in (nil, nil) => { b, a in f[a, b] } } })
+			value: { A, B, C in (A --> B --> C) => { f in (nil, nil) => { b, a in f[a, b] } } })
 
 		return Module("Prelude", [ identity, constant, flip ])
 	}

--- a/Manifold/Module+Prelude.swift
+++ b/Manifold/Module+Prelude.swift
@@ -12,7 +12,7 @@ extension Module {
 
 		let flip = Declaration("flip",
 			type: (.Type, .Type, .Type) => { A, B, C in (A --> B --> C) --> (B --> A --> C) },
-			value: { A, B, C in (A --> B --> C) => { f in (nil, nil) => { b, a in f[a, b] } } })
+			value: { A, B, C in (A --> B --> C) => { f in () => { b, a in f[a, b] } } })
 
 		return Module("Prelude", [ identity, constant, flip ])
 	}

--- a/Manifold/Module+Prelude.swift
+++ b/Manifold/Module+Prelude.swift
@@ -4,15 +4,15 @@ extension Module {
 	public static var prelude: Module {
 		let identity = Declaration("identity",
 			type: .Type => { A in A --> A },
-			value: .Type => { A in A => id })
+			value: nil => { A in A => id })
 
 		let constant = Declaration("constant",
 			type: (.Type, .Type) => { A, B in A --> B --> A },
-			value: (.Type, .Type) => { A, B in A => { B => const($0) } })
+			value: (nil, nil) => { A, B in A => { B => const($0) } })
 
 		let flip = Declaration("flip",
-			type: (.Type, .Type, .Type) => { A, B, C in ((A --> B --> C) --> (B --> A --> C)) },
-			value: (.Type, .Type, .Type) => { A, B, C in ((A --> B --> C)) => { f in (B, A) => { b, a in f[a, b] } } })
+			type: (.Type, .Type, .Type) => { A, B, C in (A --> B --> C) --> (B --> A --> C) },
+			value: (nil, nil, nil) => { A, B, C in (A --> B --> C) => { f in (nil, nil) => { b, a in f[a, b] } } })
 
 		return Module("Prelude", [ identity, constant, flip ])
 	}

--- a/Manifold/Module+Sigma.swift
+++ b/Manifold/Module+Sigma.swift
@@ -10,11 +10,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] --> A } },
-			value: nil => { A in nil => { B in nil => { v in v[A, nil => { x in B[x] => const(x) }] } } })
+			value: { A in nil => { B in nil => { v in v[A, nil => { x in B[x] => const(x) }] } } })
 
 		let second = Declaration("second",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in B[first.ref[A, B, v]] } } },
-			value: nil => { A in nil => { B in nil => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], nil => { x in B[x] => id }] } } })
+			value: { A in nil => { B in nil => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], nil => { x in B[x] => id }] } } })
 
 		return Module("Sigma", [ Sigma, first, second ])
 	}

--- a/Manifold/Module+Sigma.swift
+++ b/Manifold/Module+Sigma.swift
@@ -10,11 +10,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] --> A } },
-			value: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in v[A, A => { (x: Term) in B[x] => const(x) }] } } })
+			value: nil => { A in nil => { B in nil => { v in v[A, nil => { x in B[x] => const(x) }] } } })
 
 		let second = Declaration("second",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in B[first.ref[A, B, v]] } } },
-			value: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in v[(A => { (x: Term) in B[x] })[first.ref[A, B, v]], A => { (x: Term) in B[x] => id }] } } })
+			value: nil => { A in nil => { B in nil => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], nil => { x in B[x] => id }] } } })
 
 		return Module("Sigma", [ Sigma, first, second ])
 	}

--- a/Manifold/Module+Sigma.swift
+++ b/Manifold/Module+Sigma.swift
@@ -10,11 +10,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] --> A } },
-			value: { A in nil => { B in nil => { v in v[A, nil => { x in B[x] => const(x) }] } } })
+			value: { A in () => { B in () => { v in v[A, () => { x in B[x] => const(x) }] } } })
 
 		let second = Declaration("second",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in B[first.ref[A, B, v]] } } },
-			value: { A in nil => { B in nil => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], nil => { x in B[x] => id }] } } })
+			value: { A in () => { B in () => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], () => { x in B[x] => id }] } } })
 
 		return Module("Sigma", [ Sigma, first, second ])
 	}

--- a/Manifold/Module+Vector.swift
+++ b/Manifold/Module+Vector.swift
@@ -6,17 +6,17 @@ extension Module {
 		let Vector: Term = "Vector"
 		let vector = Declaration("Vector",
 			type: .Type --> Natural --> .Type,
-			value: (nil, nil, .Type) => { A, n, B in n[.Type, B --> B, Natural => { n in (A --> Vector[A, n] --> B) --> B }] })
+			value: { A, n in .Type => { B in n[.Type, B --> B, Natural => { n in (A --> Vector[A, n] --> B) --> B }] } })
 
 		let successor: Term = "successor"
 		let cons = Declaration("cons",
 			type: (.Type, Natural)  => { A, n in A --> Vector[A, n] --> Vector[A, successor[n]] },
-			value: (nil, nil) => { A, n in (nil, nil, nil) => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
+			value: { A, n in (nil, nil, nil) => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
 
 		let zero: Term = "zero"
 		let `nil` = Declaration("nil",
 			type: .Type => { A in Vector[A, zero] },
-			value: (nil, nil) => { A, B in B => id })
+			value: { A, B in B => id })
 
 		return Module("Vector", [ natural ], [ vector, cons, `nil` ])
 	}

--- a/Manifold/Module+Vector.swift
+++ b/Manifold/Module+Vector.swift
@@ -6,17 +6,17 @@ extension Module {
 		let Vector: Term = "Vector"
 		let vector = Declaration("Vector",
 			type: .Type --> Natural --> .Type,
-			value: (.Type, Natural, .Type) => { A, n, B in n[.Type, B --> B, Natural => { n in (A --> Vector[A, n] --> B) --> B }] })
+			value: (nil, nil, .Type) => { A, n, B in n[.Type, B --> B, Natural => { n in (A --> Vector[A, n] --> B) --> B }] })
 
 		let successor: Term = "successor"
 		let cons = Declaration("cons",
 			type: (.Type, Natural)  => { A, n in A --> Vector[A, n] --> Vector[A, successor[n]] },
-			value: (.Type, Natural) => { (A: Term, n) in (A, Vector[A, n], .Type) => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
+			value: (nil, nil) => { A, n in (nil, nil, nil) => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
 
 		let zero: Term = "zero"
 		let `nil` = Declaration("nil",
-			type: .Type => { (A: Term) in Vector[A, zero] },
-			value: (.Type, .Type) => { A, B in B => id })
+			type: .Type => { A in Vector[A, zero] },
+			value: (nil, nil) => { A, B in B => id })
 
 		return Module("Vector", [ natural ], [ vector, cons, `nil` ])
 	}

--- a/Manifold/Module+Vector.swift
+++ b/Manifold/Module+Vector.swift
@@ -11,7 +11,7 @@ extension Module {
 		let successor: Term = "successor"
 		let cons = Declaration("cons",
 			type: (.Type, Natural)  => { A, n in A --> Vector[A, n] --> Vector[A, successor[n]] },
-			value: { A, n in (nil, nil, nil) => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
+			value: { A, n in () => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
 
 		let zero: Term = "zero"
 		let `nil` = Declaration("nil",

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -35,11 +35,6 @@ extension Term {
 	public init(integerLiteral value: Int) {
 		self.init(.Variable(.Local(value)))
 	}
-
-
-	public init(stringLiteral value: String) {
-		self.init(.Variable(.Global(value)))
-	}
 }
 
 

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -66,7 +66,7 @@ public func => (type: Term?, body: Term -> Term) -> Term {
 
 }
 
-public func => (left: (Term, Term), right: (Term, Term) -> Term) -> Term {
+public func => (left: (Term?, Term?), right: (Term, Term) -> Term) -> Term {
 	return left.0 => { a in left.1 => { b in right(a, b) } }
 }
 

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -57,7 +57,7 @@ public func --> (left: Term, right: Term) -> Term {
 	return left => const(right)
 }
 
-public func => (type: Term, body: Term -> Term) -> Term {
+public func => (type: Term?, body: Term -> Term) -> Term {
 	var n = -1
 	let body = body(Term { .Variable(.Local(n)) })
 	n = body.maxBoundVariable + 1

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -17,7 +17,7 @@ extension Term {
 		return Term(.Application(a, b))
 	}
 
-	public static func Lambda(i: Int, _ type: Term, _ body: Term) -> Term {
+	public static func Lambda(i: Int, _ type: Term?, _ body: Term) -> Term {
 		return Term(.Lambda(i, type, body))
 	}
 

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -56,12 +56,24 @@ public func => (type: Term?, body: Term -> Term) -> Term {
 
 }
 
+public func => (type: (), body: Term -> Term) -> Term {
+	return nil => body
+}
+
 public func => (left: (Term?, Term?), right: (Term, Term) -> Term) -> Term {
 	return left.0 => { a in left.1 => { b in right(a, b) } }
 }
 
+public func => (left: (), right: (Term, Term) -> Term) -> Term {
+	return nil => { a in nil => { b in right(a, b) } }
+}
+
 public func => (left: (Term?, Term?, Term?), right: (Term, Term, Term) -> Term) -> Term {
 	return left.0 => { a in left.1 => { b in left.2 => { c in right(a, b, c) } } }
+}
+
+public func => (left: (), right: (Term, Term, Term) -> Term) -> Term {
+	return nil => { a in nil => { b in nil => { c in right(a, b, c) } } }
 }
 
 

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -70,7 +70,7 @@ public func => (left: (Term?, Term?), right: (Term, Term) -> Term) -> Term {
 	return left.0 => { a in left.1 => { b in right(a, b) } }
 }
 
-public func => (left: (Term, Term, Term), right: (Term, Term, Term) -> Term) -> Term {
+public func => (left: (Term?, Term?, Term?), right: (Term, Term, Term) -> Term) -> Term {
 	return left.0 => { a in left.1 => { b in left.2 => { c in right(a, b, c) } } }
 }
 

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -30,11 +30,6 @@ extension Term {
 	public init<T: TermContainerType>(term: T) {
 		self.init(term.out.map { Term(term: $0) })
 	}
-
-
-	public init(integerLiteral value: Int) {
-		self.init(.Variable(.Local(value)))
-	}
 }
 
 

--- a/Manifold/Term+DefinitionalEquality.swift
+++ b/Manifold/Term+DefinitionalEquality.swift
@@ -27,7 +27,7 @@ extension Term {
 		case let (.Application(a1, a2), .Application(b1, b2)):
 			return recur(a1, b1) && recur(a2, b2)
 
-		case let (.Lambda(_, a1, a2), .Lambda(_, b1, b2)):
+		case let (.Lambda(_, .Some(a1), a2), .Lambda(_, .Some(b1), b2)):
 			return recur(a1, b1) && recur(a2, b2)
 
 		default:

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -23,7 +23,7 @@ extension Term {
 				let bʹ = try b.elaborateType(type, environment, context)
 				return .Unroll(body.substitute(i, b), .Application(a, bʹ))
 
-			case let (.Lambda(i, a, b), .None):
+			case let (.Lambda(i, .Some(a), b), .None):
 				let aʹ = try a.elaborateType(.Type, environment, context)
 				let bʹ = try b.elaborateType(nil, environment, context + [ .Local(i): a ])
 				return .Unroll(a => { bʹ.type.substitute(i, $0) }, .Lambda(i, aʹ, bʹ))
@@ -31,12 +31,12 @@ extension Term {
 			case let (.Type(m), .Some(.Type(n))) where n > m:
 				return try elaborateType(nil, environment, context)
 
-			case let (.Lambda(i, type1, body), .Some(.Lambda(j, type2, bodyType))) where Term.equate(type1, type2, environment):
-				let t = try type1.elaborateType(.Type, environment, context)
-				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type1 ])
+			case let (.Lambda(i, .Some(type), body), .Some(.Lambda(j, .Some(type2), bodyType))) where Term.equate(type, type2, environment):
+				let t = try type.elaborateType(.Type, environment, context)
+				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type ])
 				return .Unroll(.Lambda(j, type2, bodyType), .Lambda(i, t, b))
 
-			case let (.Lambda(i, type, body), .Some(.Type)):
+			case let (.Lambda(i, .Some(type), body), .Some(.Type)):
 				try type.elaborateType(.Type, environment, context)
 				return try body.elaborateType(.Type, environment, context + [ Name.Local(i) : type ])
 
@@ -46,6 +46,9 @@ extension Term {
 					throw "Type mismatch: expected '\(self)' to be of type '\(Term(b))', but it was actually of type '\(a.type)' in context: \(Term.toString(context, separator: ":")), environment: \(Term.toString(environment, separator: "="))"
 				}
 				return a
+
+			default:
+				throw "No rule to infer type of '\(self)'"
 			}
 		} catch let e {
 			throw "\(e)\nin: '\(self)'" + (against.map { " ⇐ '\($0)'" } ?? " ⇒ ?")

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -36,6 +36,11 @@ extension Term {
 				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type ])
 				return .Unroll(.Lambda(j, type2, bodyType), .Lambda(i, t, b))
 
+			case let (.Lambda(i, .None, body), .Some(.Lambda(j, .Some(type), bodyType))):
+				let t = try type.elaborateType(.Type, environment, context)
+				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type ])
+				return .Unroll(.Lambda(j, type, bodyType), .Lambda(i, t, b))
+
 			case let (.Lambda(i, .Some(type), body), .Some(.Type)):
 				try type.elaborateType(.Type, environment, context)
 				return try body.elaborateType(.Type, environment, context + [ Name.Local(i) : type ])

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -13,6 +13,13 @@ public enum Term: IntegerLiteralConvertible, StringLiteralConvertible, TermConta
 	}
 
 
+	// MARK: StringLiteralConvertible
+
+	public init(stringLiteral value: String) {
+		self.init(.Variable(.Global(value)))
+	}
+
+
 	// MARK: TermContainerType
 
 	public var out: Expression<Term> {

--- a/Manifold/Term.swift
+++ b/Manifold/Term.swift
@@ -13,6 +13,13 @@ public enum Term: IntegerLiteralConvertible, StringLiteralConvertible, TermConta
 	}
 
 
+	// MARK: IntegerLiteralConvertible
+
+	public init(integerLiteral value: Int) {
+		self.init(.Variable(.Local(value)))
+	}
+
+
 	// MARK: StringLiteralConvertible
 
 	public init(stringLiteral value: String) {

--- a/Manifold/TermContainerType+CustomStringConvertible.swift
+++ b/Manifold/TermContainerType+CustomStringConvertible.swift
@@ -20,10 +20,13 @@ extension TermContainerType {
 			case let .Application((_, (a, _)), (_, b)):
 				return ("\(a) \(wrap(b))", true)
 
-			case let .Lambda(variable, (_, type), (b, (body, _))):
+			case let .Lambda(variable, .Some(_, type), (b, (body, _))):
 				return (b.freeVariables.contains(variable)
 					? "λ \(Name.Local(variable)) : \(type.0) . \(body)"
 					: "\(wrap(type)) → \(body)", true)
+
+			case let .Lambda(variable, _, (_, (body, _))):
+				return ("λ \(Name.Local(variable)) . \(body)", true)
 			}
 		}
 		return out

--- a/Manifold/TermContainerType+FreeVariables.swift
+++ b/Manifold/TermContainerType+FreeVariables.swift
@@ -10,8 +10,10 @@ extension TermContainerType {
 				return -1
 			case let .Application(a, b):
 				return max(a, b)
-			case let .Lambda(i, a, b):
+			case let .Lambda(i, .Some(a), b):
 				return i < 0 ? max(a, b) : max(i, a)
+			case let .Lambda(i, .None, b):
+				return i < 0 ? b : i
 			}
 		}
 	}
@@ -26,7 +28,7 @@ extension TermContainerType {
 			case let .Application(a, b):
 				return a.union(b)
 			case let .Lambda(i, a, b):
-				return a.union(b.subtract([ i ]))
+				return b.subtract([ i ]).union(a ?? [])
 			}
 		}
 	}

--- a/ManifoldTests/ListTests.swift
+++ b/ManifoldTests/ListTests.swift
@@ -22,7 +22,7 @@ private let expected: Module = {
 
 	let cons = Declaration("cons",
 		type: .Type => { A in A --> List[A] --> List[A] },
-		value: .Type => { (A: Term) in (A, List[A], .Type) => { head, tail, B in (A --> List[A] --> B, B) => { ifCons, _ in ifCons[head, tail] } } })
+		value: .Type => { A in (A, List[A], .Type) => { head, tail, B in (A --> List[A] --> B, B) => { ifCons, _ in ifCons[head, tail] } } })
 
 	let `nil` = Declaration("nil",
 		type: .Type => { (A: Term) in List[A] },

--- a/ManifoldTests/SigmaTests.swift
+++ b/ManifoldTests/SigmaTests.swift
@@ -20,7 +20,7 @@ private let expected: Module = {
 		value: .Type => { A in (A --> .Type, .Type) => { B, C in (A => { x in B[x] --> C }) --> C } })
 
 	let sigma = Declaration("sigma",
-		type: .Type => { A in (A --> .Type, A) => { (B, x: Term) in B[x] --> Sigma.ref[A, B] } },
+		type: .Type => { A in (A --> .Type, A) => { B, x in B[x] --> Sigma.ref[A, B] } },
 		value: .Type => { A in (A --> .Type, A) => { B, x in (B[x], .Type) => { y, C in (A => { xʹ in B[xʹ] --> C }) => { f in f[x, y] } } } })
 
 	return Module("ChurchSigma", [ Sigma, sigma ])


### PR DESCRIPTION
Type annotations can be left off of lambdas, and the types inferred from annotations higher up.
- [x] `(nil, nil) => { a, b in … }` is ugly.
- ~~Leaving off the only use of a type parameter breaks definitions by remapping it to -1.~~ Oh well.
