### PR TITLE
Functor typeclass as a type

### DIFF
--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		D4FB02D91B71D06A0090E764 /* Module+Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FB02D81B71D06A0090E764 /* Module+Boolean.swift */; };
 		D4FB2D071BE447DE00B3CCE0 /* Module+Directory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FB2D061BE447DE00B3CCE0 /* Module+Directory.swift */; };
 		D4FB2D091BE4490000B3CCE0 /* ModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FB2D081BE4490000B3CCE0 /* ModuleTests.swift */; };
+		D4FB2D0B1BE44DAF00B3CCE0 /* Module+Functor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FB2D0A1BE44DAF00B3CCE0 /* Module+Functor.swift */; };
 		D4FC2FDE1BAF564F005F3B26 /* DeclarationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FC2FDD1BAF564F005F3B26 /* DeclarationTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -113,6 +114,7 @@
 		D4FB02D81B71D06A0090E764 /* Module+Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+Boolean.swift"; sourceTree = "<group>"; };
 		D4FB2D061BE447DE00B3CCE0 /* Module+Directory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+Directory.swift"; sourceTree = "<group>"; };
 		D4FB2D081BE4490000B3CCE0 /* ModuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModuleTests.swift; sourceTree = "<group>"; };
+		D4FB2D0A1BE44DAF00B3CCE0 /* Module+Functor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+Functor.swift"; sourceTree = "<group>"; };
 		D4FC2FDD1BAF564F005F3B26 /* DeclarationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeclarationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -238,6 +240,7 @@
 				D4D0FC0D1BD4A6D80010F243 /* Module+Sigma.swift */,
 				D470CB971BDC27130003A931 /* Module+Vector.swift */,
 				D4ACE90C1BDC7E51009E928F /* Module+FiniteSet.swift */,
+				D4FB2D0A1BE44DAF00B3CCE0 /* Module+Functor.swift */,
 			);
 			name = Modules;
 			sourceTree = "<group>";
@@ -368,6 +371,7 @@
 				D44541801BCAC38500F2946D /* Module+List.swift in Sources */,
 				D463F6D21BD2A83E00BA0628 /* Module+Maybe.swift in Sources */,
 				D4E990241BD3EE5300F00CA7 /* Elaborated.swift in Sources */,
+				D4FB2D0B1BE44DAF00B3CCE0 /* Module+Functor.swift in Sources */,
 				D445418E1BCAF57D00F2946D /* Term+Evaluation.swift in Sources */,
 				D4D0FC001BD420B20010F243 /* Term+Elaboration.swift in Sources */,
 				D4ACE90D1BDC7E51009E928F /* Module+FiniteSet.swift in Sources */,

--- a/Manifold/Declaration.swift
+++ b/Manifold/Declaration.swift
@@ -17,6 +17,10 @@ public enum Declaration: CustomStringConvertible {
 		self = .Definition(symbol, type, (nil, nil, nil) => value)
 	}
 
+	public init(_ symbol: Name, type: Term, value: (Term, Term, Term, Term) -> Term) {
+		self = .Definition(symbol, type, (nil, nil, nil, nil) => value)
+	}
+
 	public init(_ symbol: Name, _ datatype: Manifold.Datatype) {
 		self = .Datatype(symbol, datatype)
 	}

--- a/Manifold/Module+Functor.swift
+++ b/Manifold/Module+Functor.swift
@@ -1,0 +1,7 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension Module {
+	public static var functor: Module {
+		return Module("Functor", [])
+	}
+}

--- a/Manifold/Module+Functor.swift
+++ b/Manifold/Module+Functor.swift
@@ -8,7 +8,7 @@ extension Module {
 
 		let map = Declaration("map",
 			type: .Type --> .Type => { f in (Functor.ref[f], .Type, .Type) => { F, A, B in (A --> B) --> f[A] --> f[B] } },
-			value: .Type)
+			value: { f in () => { F, A, B in (A --> B, f[A]) => { transform, functor in F[A, B, functor] } } })
 
 		return Module("Functor", [ Functor, map ])
 	}

--- a/Manifold/Module+Functor.swift
+++ b/Manifold/Module+Functor.swift
@@ -6,7 +6,11 @@ extension Module {
 			[ "functor": Telescope.Argument((.Type, .Type) => { A, B in (A --> B) --> f[A] --> f[B] }, const(.End)) ]
 		}))
 
-		return Module("Functor", [ Functor ])
+		let map = Declaration("map",
+			type: .Type --> .Type => { Functor.ref[$0] },
+			value: .Type)
+
+		return Module("Functor", [ Functor, map ])
 	}
 }
 

--- a/Manifold/Module+Functor.swift
+++ b/Manifold/Module+Functor.swift
@@ -2,6 +2,13 @@
 
 extension Module {
 	public static var functor: Module {
-		return Module("Functor", [])
+		let Functor = Declaration("Functor", Datatype(.Type --> .Type, { f in
+			[ "functor": Telescope.Argument((.Type, .Type) => { A, B in (A --> B) --> f[A] --> f[B] }, const(.End)) ]
+		}))
+
+		return Module("Functor", [ Functor ])
 	}
 }
+
+
+import Prelude

--- a/Manifold/Module+Functor.swift
+++ b/Manifold/Module+Functor.swift
@@ -7,7 +7,7 @@ extension Module {
 		}))
 
 		let map = Declaration("map",
-			type: .Type --> .Type => { Functor.ref[$0] },
+			type: .Type --> .Type => { f in (Functor.ref[f], .Type, .Type) => { F, A, B in (A --> B) --> f[A] --> f[B] } },
 			value: .Type)
 
 		return Module("Functor", [ Functor, map ])

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -9,9 +9,11 @@ extension Module {
 			]
 		})
 
+		let cons: Term = "cons"
+		let `nil`: Term = "nil"
 		let map = Declaration("List.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
-			value: .Type)
+			value: { A, B in (A --> B, nil) => { transform, list in list[List.ref[B], () => { cons[B, transform[$0]] }, `nil`[B]] } })
 
 		return Module("List", [ List, map ])
 	}

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -11,9 +11,10 @@ extension Module {
 
 		let cons: Term = "cons"
 		let `nil`: Term = "nil"
+		let listMap: Term = "List.map"
 		let map = Declaration("List.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
-			value: { A, B in (A --> B, nil) => { transform, list in list[List.ref[B], () => { cons[B, transform[$0]] }, `nil`[B]] } })
+			value: { A, B in (A --> B, nil) => { transform, list in list[List.ref[B], () => { cons[B, transform[$0], listMap[A, B, transform, $1]] }, `nil`[B]] } })
 
 		return Module("List", [ List, map ])
 	}

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -20,9 +20,10 @@ extension Module {
 			type: .Type => { A in A --> List.ref[A] },
 			value: { A, a in cons[A, a, `nil`[A]] })
 
+		let _cat: Term = "cat"
 		let cat = Declaration("cat",
 			type: .Type => { A in List.ref[A] --> List.ref[A] --> List.ref[A] },
-			value: .Type)
+			value: { A, x, y in x[List.ref[A], () => { cons[A, $0, _cat[A, $1, y]] }, y] })
 
 		let _join: Term = "List.join"
 		let join = Declaration("List.join",

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -11,10 +11,10 @@ extension Module {
 
 		let cons: Term = "cons"
 		let `nil`: Term = "nil"
-		let listMap: Term = "List.map"
+		let _map: Term = "List.map"
 		let map = Declaration("List.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
-			value: { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], listMap[A, B, transform, $1]] }, `nil`[B]] })
+			value: { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], _map[A, B, transform, $1]] }, `nil`[B]] })
 
 		let pure = Declaration("List.pure",
 			type: .Type => { A in A --> List.ref[A] },

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -20,6 +20,10 @@ extension Module {
 			type: .Type => { A in A --> List.ref[A] },
 			value: { A, a in cons[A, a, `nil`[A]] })
 
+		let cat = Declaration("cat",
+			type: .Type => { A in List.ref[A] --> List.ref[A] --> List.ref[A] },
+			value: .Type)
+
 		let join = Declaration("List.join",
 			type: .Type => { A in List.ref[List.ref[A]] --> List.ref[A] },
 			value: .Type)
@@ -28,7 +32,7 @@ extension Module {
 			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
 			value: { A, B, transform, list in join.ref[B, map.ref[A, List.ref[B], transform, list]] })
 
-		return Module("List", [ List, map, pure, join, bind ])
+		return Module("List", [ List, map, pure, cat, join, bind ])
 	}
 }
 

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -26,7 +26,7 @@ extension Module {
 
 		let bind = Declaration("List.bind",
 			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
-			value: .Type)
+			value: { A, B, transform, list in join.ref[B, map.ref[A, List.ref[B], transform, list]] })
 
 		return Module("List", [ List, map, pure, join, bind ])
 	}

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -14,7 +14,7 @@ extension Module {
 		let listMap: Term = "List.map"
 		let map = Declaration("List.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
-			value: { A, B in (A --> B, nil) => { transform, list in list[List.ref[B], () => { cons[B, transform[$0], listMap[A, B, transform, $1]] }, `nil`[B]] } })
+			value: { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], listMap[A, B, transform, $1]] }, `nil`[B]] })
 
 		return Module("List", [ List, map ])
 	}

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -16,7 +16,11 @@ extension Module {
 			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
 			value: { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], listMap[A, B, transform, $1]] }, `nil`[B]] })
 
-		return Module("List", [ List, map ])
+		let bind = Declaration("List.bind",
+			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
+			value: .Type)
+
+		return Module("List", [ List, map, bind ])
 	}
 }
 

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -8,7 +8,12 @@ extension Module {
 				"nil": .End
 			]
 		})
-		return Module("List", [ List ])
+
+		let map = Declaration("List.map",
+			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
+			value: .Type)
+
+		return Module("List", [ List, map ])
 	}
 }
 

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -18,7 +18,7 @@ extension Module {
 
 		let pure = Declaration("List.pure",
 			type: .Type => { A in A --> List.ref[A] },
-			value: .Type)
+			value: { A, a in cons[A, a, `nil`[A]] })
 
 		let bind = Declaration("List.bind",
 			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -2,14 +2,13 @@
 
 extension Module {
 	public static var list: Module {
-		return Module("List", [
-			Declaration("List", Datatype(.Type) {
-				[
-					"cons": .Argument($0, const(.Recursive(.End))),
-					"nil": .End
-				]
-			})
-		])
+		let List = Declaration("List", Datatype(.Type) {
+			[
+				"cons": .Argument($0, const(.Recursive(.End))),
+				"nil": .End
+			]
+		})
+		return Module("List", [ List ])
 	}
 }
 

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -20,11 +20,15 @@ extension Module {
 			type: .Type => { A in A --> List.ref[A] },
 			value: { A, a in cons[A, a, `nil`[A]] })
 
+		let join = Declaration("List.join",
+			type: .Type => { A in List.ref[List.ref[A]] --> List.ref[A] },
+			value: .Type)
+
 		let bind = Declaration("List.bind",
 			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
 			value: .Type)
 
-		return Module("List", [ List, map, pure, bind ])
+		return Module("List", [ List, map, pure, join, bind ])
 	}
 }
 

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -16,11 +16,15 @@ extension Module {
 			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
 			value: { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], listMap[A, B, transform, $1]] }, `nil`[B]] })
 
+		let pure = Declaration("List.pure",
+			type: .Type => { A in A --> List.ref[A] },
+			value: .Type)
+
 		let bind = Declaration("List.bind",
 			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
 			value: .Type)
 
-		return Module("List", [ List, map, bind ])
+		return Module("List", [ List, map, pure, bind ])
 	}
 }
 

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -24,9 +24,10 @@ extension Module {
 			type: .Type => { A in List.ref[A] --> List.ref[A] --> List.ref[A] },
 			value: .Type)
 
+		let _join: Term = "List.join"
 		let join = Declaration("List.join",
 			type: .Type => { A in List.ref[List.ref[A]] --> List.ref[A] },
-			value: .Type)
+			value: { A, list in list[List.ref[A], () => { cat.ref[A, $0, _join[A, $1]] }, `nil`[A]] })
 
 		let bind = Declaration("List.bind",
 			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -2,14 +2,13 @@
 
 extension Module {
 	public static var maybe: Module {
-		return Module("Maybe", [
-			Declaration.Datatype("Maybe", .Argument(.Type, {
-				[
-					"just": .Argument($0, const(.End)),
-					"nothing": .End
-				]
-			}))
-		])
+		let Maybe = Declaration.Datatype("Maybe", .Argument(.Type, {
+			[
+				"just": .Argument($0, const(.End)),
+				"nothing": .End
+			]
+		}))
+		return Module("Maybe", [ Maybe ])
 	}
 }
 

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -13,7 +13,7 @@ extension Module {
 		let nothing: Term = "nothing"
 		let map = Declaration("Maybe.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> Maybe.ref[A] --> Maybe.ref[B] },
-			value: { A, B, transform, maybe in maybe[Maybe.ref[B], () => { just[transform[$0]] }, nothing[B]] })
+			value: { A, B in (A --> B, nil) => { transform, maybe in maybe[Maybe.ref[B], () => { just[transform[$0]] }, nothing[B]] } })
 
 		return Module("Maybe", [ Maybe, map ])
 	}

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -8,7 +8,12 @@ extension Module {
 				"nothing": .End
 			]
 		}))
-		return Module("Maybe", [ Maybe ])
+
+		let map = Declaration("Maybe.map",
+			type: (.Type, .Type) => { A, B in (A --> B) --> Maybe.ref[A] --> Maybe.ref[B] },
+			value: .Type)
+
+		return Module("Maybe", [ Maybe, map ])
 	}
 }
 

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -9,9 +9,11 @@ extension Module {
 			]
 		}))
 
+		let just: Term = "just"
+		let nothing: Term = "nothing"
 		let map = Declaration("Maybe.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> Maybe.ref[A] --> Maybe.ref[B] },
-			value: .Type)
+			value: { A, B, transform, maybe in maybe[Maybe.ref[B], () => { just[transform[$0]] }, nothing[B]] })
 
 		return Module("Maybe", [ Maybe, map ])
 	}

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -13,7 +13,7 @@ extension Module {
 		let nothing: Term = "nothing"
 		let map = Declaration("Maybe.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> Maybe.ref[A] --> Maybe.ref[B] },
-			value: { A, B in (A --> B, nil) => { transform, maybe in maybe[Maybe.ref[B], () => { just[transform[$0]] }, nothing[B]] } })
+			value: { A, B in (A --> B, nil) => { transform, maybe in maybe[Maybe.ref[B], () => { just[B, transform[$0]] }, nothing[B]] } })
 
 		return Module("Maybe", [ Maybe, map ])
 	}

--- a/Manifold/Module+Sigma.swift
+++ b/Manifold/Module+Sigma.swift
@@ -2,7 +2,7 @@
 
 extension Module {
 	public static var sigma: Module {
-		let Sigma = Declaration.Datatype("Sigma", Datatype.Argument(.Type, { A in
+		let Sigma = Declaration("Sigma", Datatype(.Type, { A in
 			Datatype.Argument(A --> .Type) { B in
 				[ "sigma": Telescope.Argument(A) { a in .Argument(B[a], const(.End)) } ]
 			}

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -76,5 +76,13 @@ public func => (left: (), right: (Term, Term, Term) -> Term) -> Term {
 	return nil => { a in nil => { b in nil => { c in right(a, b, c) } } }
 }
 
+public func => (left: (Term?, Term?, Term?, Term?), right: (Term, Term, Term, Term) -> Term) -> Term {
+	return left.0 => { a in left.1 => { b in left.2 => { c in left.3 => { d in right(a, b, c, d) } } } }
+}
+
+public func => (left: (), right: (Term, Term, Term, Term) -> Term) -> Term {
+	return nil => { a in nil => { b in nil => { c in nil => { d in right(a, b, c, d) } } } }
+}
+
 
 import Prelude


### PR DESCRIPTION
- [x] Fixes #150.
- [x] Implements `Functor` as a type parameterized by some _f_ : Type → Type.
- [x] Implements `Maybe.map`.
- [x] Implements `List.map`.
- [x] Implements `List.pure`.
- [x] Implements `List.join`.
- [x] Implements `List.bind`.
- [x] Implements `cat` over `List`.

I’m curious how `Functor` will work out in practice. We have enough to define `Functor` instances for both `Maybe` and `List`, plus a `Monad` instance for `List` (if we had a `Monad` typeclass). I just don’t know how to use these instances yet.
