### PR TITLE
Evaluation throws

### DIFF
--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -7,7 +7,7 @@ extension Term {
 			if let found = environment[i] {
 				return found
 			}
-			fatalError("Illegal free variable \(i)")
+			throw "Illegal free variable \(i)"
 		case let .Application(a, b):
 			let a = try a.evaluate(environment)
 			if case let .Lambda(i, _, body) = a.out {

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Term {
-	public func evaluate(environment: [Name:Term] = [:]) -> Term {
+	public func evaluate(environment: [Name:Term] = [:]) throws -> Term {
 		switch out {
 		case let .Variable(i):
 			if let found = environment[i] {
@@ -9,9 +9,9 @@ extension Term {
 			}
 			fatalError("Illegal free variable \(i)")
 		case let .Application(a, b):
-			let a = a.evaluate(environment)
+			let a = try a.evaluate(environment)
 			if case let .Lambda(i, _, body) = a.out {
-				return body.substitute(i, b.evaluate(environment)).evaluate(environment)
+				return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
 			}
 			fatalError("Illegal application of non-lambda term \(a) to \(b)")
 		default:

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -13,7 +13,7 @@ extension Term {
 			if case let .Lambda(i, _, body) = a.out {
 				return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
 			}
-			fatalError("Illegal application of non-lambda term \(a) to \(b)")
+			throw "Illegal application of non-lambda term \(a) to \(b)"
 		default:
 			return self
 		}

--- a/ManifoldTests/EvaluationTests.swift
+++ b/ManifoldTests/EvaluationTests.swift
@@ -2,21 +2,21 @@
 
 final class EvaluationTests: XCTestCase {
 	func testTypeEvaluatesToItself() {
-		assert(Term(.Type(0)).evaluate(), ==, .Type(0))
+		assert(try? Term(.Type(0)).evaluate(), ==, .Type(0))
 	}
 
 	func testApplicationOfIdentityAbstractionToTermEvaluatesToTerm() {
 		let identity: Term = .Type => id
-		assert(Term.Application(identity, .Type).evaluate(), ==, .Type)
+		assert(try? Term.Application(identity, .Type).evaluate(), ==, .Type)
 	}
 
 	func testSimpleAbstractionEvaluatesToItself() {
 		let identity: Term = .Type => id
-		assert(identity.evaluate(), ==, identity)
+		assert(try? identity.evaluate(), ==, identity)
 	}
 
 	func testAbstractionsBodiesAreNotNormalized() {
-		assert(identity.value.evaluate(), ==, identity.value)
+		assert(try? identity.value.evaluate(), ==, identity.value)
 	}
 }
 


### PR DESCRIPTION
Evaluation `throws` errors instead of failing via `fatalError`.
