### PR TITLE
Implicit parameters

### DIFF
--- a/Manifold/Declaration.swift
+++ b/Manifold/Declaration.swift
@@ -5,22 +5,6 @@ public enum Declaration: CustomStringConvertible {
 		self = .Definition(symbol, type, value)
 	}
 
-	public init(_ symbol: Name, type: Term, value: Term -> Term) {
-		self = .Definition(symbol, type, nil => value)
-	}
-
-	public init(_ symbol: Name, type: Term, value: (Term, Term) -> Term) {
-		self = .Definition(symbol, type, (nil, nil) => value)
-	}
-
-	public init(_ symbol: Name, type: Term, value: (Term, Term, Term) -> Term) {
-		self = .Definition(symbol, type, (nil, nil, nil) => value)
-	}
-
-	public init(_ symbol: Name, type: Term, value: (Term, Term, Term, Term) -> Term) {
-		self = .Definition(symbol, type, (nil, nil, nil, nil) => value)
-	}
-
 	public init(_ symbol: Name, _ datatype: Manifold.Datatype) {
 		self = .Datatype(symbol, datatype)
 	}

--- a/Manifold/Module+Boolean.swift
+++ b/Manifold/Module+Boolean.swift
@@ -12,23 +12,23 @@ extension Module {
 
 		let not = Declaration("not",
 			type: Boolean.ref --> Boolean.ref,
-			value: { b, A in () => { t, f in b[A, f, t] } })
+			value: () => { b, A in () => { t, f in b[A, f, t] } })
 
 		let `if` = Declaration("if",
 			type: (.Type, Boolean.ref) => { A, condition in (A, A) => const(A) },
-			value: { A, condition in () => { condition[A, $0, $1] } })
+			value: () => { A, condition in () => { condition[A, $0, $1] } })
 
 		let and = Declaration("and",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: { p, q in p[Boolean.ref, q, `false`] })
+			value: () => { p, q in p[Boolean.ref, q, `false`] })
 
 		let or = Declaration("or",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: { p, q in p[Boolean.ref, `true`, q] })
+			value: () => { p, q in p[Boolean.ref, `true`, q] })
 
 		let xor = Declaration("xor",
 			type: Boolean.ref --> Boolean.ref --> Boolean.ref,
-			value: { p, q in p[Boolean.ref, not.ref[q], q] })
+			value: () => { p, q in p[Boolean.ref, not.ref[q], q] })
 
 		return Module("Boolean", [ Boolean, not, `if`, and, or, xor ])
 	}

--- a/Manifold/Module+FiniteSet.swift
+++ b/Manifold/Module+FiniteSet.swift
@@ -6,16 +6,16 @@ extension Module {
 		let FiniteSet: Term = "FiniteSet"
 		let finiteSet = Declaration("FiniteSet",
 			type: Natural --> .Type,
-			value: { n in n[.Type, .Type => { $0 --> $0 }, (Natural, .Type) => { n, A in A --> (FiniteSet[n] --> A) --> A }] })
+			value: () => { n in n[.Type, .Type => { $0 --> $0 }, (Natural, .Type) => { n, A in A --> (FiniteSet[n] --> A) --> A }] })
 
 		let successor: Term = "successor"
 		let zeroth = Declaration("zeroth",
 			type: Natural => { n in FiniteSet[successor[n]] },
-			value: { n in () => { A in () => { (FiniteSet[n] --> A) --> $0 } } })
+			value: () => { n in () => { A in () => { (FiniteSet[n] --> A) --> $0 } } })
 
 		let nextth = Declaration("nextth",
 			type: Natural => { n in FiniteSet[n] --> FiniteSet[successor[n]] },
-			value: { n in (FiniteSet[n], nil) => { prev, A in A --> () => { $0[prev] } } })
+			value: () => { n in (FiniteSet[n], nil) => { prev, A in A --> () => { $0[prev] } } })
 
 		return Module("FiniteSet", [ natural ], [ finiteSet, zeroth, nextth ])
 	}

--- a/Manifold/Module+Functor.swift
+++ b/Manifold/Module+Functor.swift
@@ -8,7 +8,7 @@ extension Module {
 
 		let map = Declaration("map",
 			type: .Type --> .Type => { f in (Functor.ref[f], .Type, .Type) => { F, A, B in (A --> B) --> f[A] --> f[B] } },
-			value: { f in () => { F, A, B in (A --> B, f[A]) => { transform, functor in F[A, B, functor] } } })
+			value: () => { f in () => { F, A, B in (A --> B, f[A]) => { transform, functor in F[A, B, functor] } } })
 
 		return Module("Functor", [ Functor, map ])
 	}

--- a/Manifold/Module+Functor.swift
+++ b/Manifold/Module+Functor.swift
@@ -7,7 +7,7 @@ extension Module {
 		}))
 
 		let map = Declaration("map",
-			type: .Type --> .Type => { f in (Functor.ref[f], .Type, .Type) => { F, A, B in (A --> B) --> f[A] --> f[B] } },
+			type: .Type --> () => { f in (Functor.ref[f], .Type, .Type) => { F, A, B in (A --> B) --> f[A] --> f[B] } },
 			value: () => { f in () => { F, A, B in (A --> B, f[A]) => { transform, functor in F[A, B, functor] } } })
 
 		return Module("Functor", [ Functor, map ])

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -13,25 +13,25 @@ extension Module {
 		let `nil`: Term = "nil"
 		let _map: Term = "List.map"
 		let map = Declaration("List.map",
-			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
+			type: () => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
 			value: () => { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], _map[A, B, transform, $1]] }, `nil`[B]] })
 
 		let pure = Declaration("List.pure",
-			type: .Type => { A in A --> List.ref[A] },
+			type: () => { A in A --> List.ref[A] },
 			value: () => { A, a in cons[A, a, `nil`[A]] })
 
 		let _cat: Term = "cat"
 		let cat = Declaration("cat",
-			type: .Type => { A in List.ref[A] --> List.ref[A] --> List.ref[A] },
+			type: () => { A in List.ref[A] --> List.ref[A] --> List.ref[A] },
 			value: () => { A, x, y in x[List.ref[A], () => { cons[A, $0, _cat[A, $1, y]] }, y] })
 
 		let _join: Term = "List.join"
 		let join = Declaration("List.join",
-			type: .Type => { A in List.ref[List.ref[A]] --> List.ref[A] },
+			type: () => { A in List.ref[List.ref[A]] --> List.ref[A] },
 			value: () => { A, list in list[List.ref[A], () => { cat.ref[A, $0, _join[A, $1]] }, `nil`[A]] })
 
 		let bind = Declaration("List.bind",
-			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
+			type: () => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
 			value: () => { A, B, transform, list in join.ref[B, map.ref[A, List.ref[B], transform, list]] })
 
 		return Module("List", [ List, map, pure, cat, join, bind ])

--- a/Manifold/Module+List.swift
+++ b/Manifold/Module+List.swift
@@ -14,25 +14,25 @@ extension Module {
 		let _map: Term = "List.map"
 		let map = Declaration("List.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> List.ref[A] --> List.ref[B] },
-			value: { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], _map[A, B, transform, $1]] }, `nil`[B]] })
+			value: () => { A, B, transform, list in list[List.ref[B], () => { cons[B, transform[$0], _map[A, B, transform, $1]] }, `nil`[B]] })
 
 		let pure = Declaration("List.pure",
 			type: .Type => { A in A --> List.ref[A] },
-			value: { A, a in cons[A, a, `nil`[A]] })
+			value: () => { A, a in cons[A, a, `nil`[A]] })
 
 		let _cat: Term = "cat"
 		let cat = Declaration("cat",
 			type: .Type => { A in List.ref[A] --> List.ref[A] --> List.ref[A] },
-			value: { A, x, y in x[List.ref[A], () => { cons[A, $0, _cat[A, $1, y]] }, y] })
+			value: () => { A, x, y in x[List.ref[A], () => { cons[A, $0, _cat[A, $1, y]] }, y] })
 
 		let _join: Term = "List.join"
 		let join = Declaration("List.join",
 			type: .Type => { A in List.ref[List.ref[A]] --> List.ref[A] },
-			value: { A, list in list[List.ref[A], () => { cat.ref[A, $0, _join[A, $1]] }, `nil`[A]] })
+			value: () => { A, list in list[List.ref[A], () => { cat.ref[A, $0, _join[A, $1]] }, `nil`[A]] })
 
 		let bind = Declaration("List.bind",
 			type: (.Type, .Type) => { A, B in (A --> List.ref[B]) --> List.ref[A] --> List.ref[B] },
-			value: { A, B, transform, list in join.ref[B, map.ref[A, List.ref[B], transform, list]] })
+			value: () => { A, B, transform, list in join.ref[B, map.ref[A, List.ref[B], transform, list]] })
 
 		return Module("List", [ List, map, pure, cat, join, bind ])
 	}

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -12,7 +12,7 @@ extension Module {
 		let just: Term = "just"
 		let nothing: Term = "nothing"
 		let map = Declaration("Maybe.map",
-			type: (.Type, .Type) => { A, B in (A --> B) --> Maybe.ref[A] --> Maybe.ref[B] },
+			type: () => { A, B in (A --> B) --> Maybe.ref[A] --> Maybe.ref[B] },
 			value: () => { A, B in (A --> B, nil) => { transform, maybe in maybe[Maybe.ref[B], () => { just[B, transform[$0]] }, nothing[B]] } })
 
 		return Module("Maybe", [ Maybe, map ])

--- a/Manifold/Module+Maybe.swift
+++ b/Manifold/Module+Maybe.swift
@@ -13,7 +13,7 @@ extension Module {
 		let nothing: Term = "nothing"
 		let map = Declaration("Maybe.map",
 			type: (.Type, .Type) => { A, B in (A --> B) --> Maybe.ref[A] --> Maybe.ref[B] },
-			value: { A, B in (A --> B, nil) => { transform, maybe in maybe[Maybe.ref[B], () => { just[B, transform[$0]] }, nothing[B]] } })
+			value: () => { A, B in (A --> B, nil) => { transform, maybe in maybe[Maybe.ref[B], () => { just[B, transform[$0]] }, nothing[B]] } })
 
 		return Module("Maybe", [ Maybe, map ])
 	}

--- a/Manifold/Module+Pair.swift
+++ b/Manifold/Module+Pair.swift
@@ -8,11 +8,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> A },
-			value: { A, B in () => { pair in pair[A, (nil, B) => { a, _ in a }] } })
+			value: () => { A, B in () => { pair in pair[A, (nil, B) => { a, _ in a }] } })
 
 		let second = Declaration("second",
 			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> B },
-			value: { A, B in () => { pair in pair[B, () => { _, b in b }] } })
+			value: () => { A, B in () => { pair in pair[B, () => { _, b in b }] } })
 
 		return Module("Pair", [ Pair, first, second ])
 	}

--- a/Manifold/Module+Pair.swift
+++ b/Manifold/Module+Pair.swift
@@ -7,11 +7,11 @@ extension Module {
 		})
 
 		let first = Declaration("first",
-			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> A },
+			type: () => { A, B in Pair.ref[A, B] --> A },
 			value: () => { A, B in () => { pair in pair[A, (nil, B) => { a, _ in a }] } })
 
 		let second = Declaration("second",
-			type: (.Type, .Type) => { A, B in Pair.ref[A, B] --> B },
+			type: () => { A, B in Pair.ref[A, B] --> B },
 			value: () => { A, B in () => { pair in pair[B, () => { _, b in b }] } })
 
 		return Module("Pair", [ Pair, first, second ])

--- a/Manifold/Module+Prelude.swift
+++ b/Manifold/Module+Prelude.swift
@@ -4,15 +4,15 @@ extension Module {
 	public static var prelude: Module {
 		let identity = Declaration("identity",
 			type: .Type => { A in A --> A },
-			value: { A in A => id })
+			value: () => { A in A => id })
 
 		let constant = Declaration("constant",
 			type: (.Type, .Type) => { A, B in A --> B --> A },
-			value: { A, B in A => { B => const($0) } })
+			value: () => { A, B in A => { B => const($0) } })
 
 		let flip = Declaration("flip",
 			type: (.Type, .Type, .Type) => { A, B, C in (A --> B --> C) --> (B --> A --> C) },
-			value: { A, B, C in (A --> B --> C) => { f in () => { b, a in f[a, b] } } })
+			value: () => { A, B, C in (A --> B --> C) => { f in () => { b, a in f[a, b] } } })
 
 		return Module("Prelude", [ identity, constant, flip ])
 	}

--- a/Manifold/Module+Prelude.swift
+++ b/Manifold/Module+Prelude.swift
@@ -3,15 +3,15 @@
 extension Module {
 	public static var prelude: Module {
 		let identity = Declaration("identity",
-			type: .Type => { A in A --> A },
+			type: () => { A in A --> A },
 			value: () => { A in A => id })
 
 		let constant = Declaration("constant",
-			type: (.Type, .Type) => { A, B in A --> B --> A },
+			type: () => { A, B in A --> B --> A },
 			value: () => { A, B in A => { B => const($0) } })
 
 		let flip = Declaration("flip",
-			type: (.Type, .Type, .Type) => { A, B, C in (A --> B --> C) --> (B --> A --> C) },
+			type: () => { A, B, C in (A --> B --> C) --> (B --> A --> C) },
 			value: () => { A, B, C in (A --> B --> C) => { f in () => { b, a in f[a, b] } } })
 
 		return Module("Prelude", [ identity, constant, flip ])

--- a/Manifold/Module+Sigma.swift
+++ b/Manifold/Module+Sigma.swift
@@ -10,11 +10,11 @@ extension Module {
 
 		let first = Declaration("first",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] --> A } },
-			value: { A in () => { B in () => { v in v[A, () => { x in B[x] => const(x) }] } } })
+			value: () => { A in () => { B in () => { v in v[A, () => { x in B[x] => const(x) }] } } })
 
 		let second = Declaration("second",
 			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in B[first.ref[A, B, v]] } } },
-			value: { A in () => { B in () => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], () => { x in B[x] => id }] } } })
+			value: () => { A in () => { B in () => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], () => { x in B[x] => id }] } } })
 
 		return Module("Sigma", [ Sigma, first, second ])
 	}

--- a/Manifold/Module+Sigma.swift
+++ b/Manifold/Module+Sigma.swift
@@ -9,11 +9,11 @@ extension Module {
 		}))
 
 		let first = Declaration("first",
-			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] --> A } },
+			type: () => { A in (A --> .Type) => { B in Sigma.ref[A, B] --> A } },
 			value: () => { A in () => { B in () => { v in v[A, () => { x in B[x] => const(x) }] } } })
 
 		let second = Declaration("second",
-			type: .Type => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in B[first.ref[A, B, v]] } } },
+			type: () => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in B[first.ref[A, B, v]] } } },
 			value: () => { A in () => { B in () => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], () => { x in B[x] => id }] } } })
 
 		return Module("Sigma", [ Sigma, first, second ])

--- a/Manifold/Module+Vector.swift
+++ b/Manifold/Module+Vector.swift
@@ -6,17 +6,17 @@ extension Module {
 		let Vector: Term = "Vector"
 		let vector = Declaration("Vector",
 			type: .Type --> Natural --> .Type,
-			value: { A, n in .Type => { B in n[.Type, B --> B, Natural => { n in (A --> Vector[A, n] --> B) --> B }] } })
+			value: () => { A, n in .Type => { B in n[.Type, B --> B, Natural => { n in (A --> Vector[A, n] --> B) --> B }] } })
 
 		let successor: Term = "successor"
 		let cons = Declaration("cons",
 			type: (.Type, Natural)  => { A, n in A --> Vector[A, n] --> Vector[A, successor[n]] },
-			value: { A, n in () => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
+			value: () => { A, n in () => { head, tail, B in (A --> Vector[A, n] --> B) => { ifCons in ifCons[head, tail] } } })
 
 		let zero: Term = "zero"
 		let `nil` = Declaration("nil",
 			type: .Type => { A in Vector[A, zero] },
-			value: { A, B in B => id })
+			value: () => { A, B in B => id })
 
 		return Module("Vector", [ natural ], [ vector, cons, `nil` ])
 	}

--- a/Manifold/Module+Vector.swift
+++ b/Manifold/Module+Vector.swift
@@ -15,7 +15,7 @@ extension Module {
 
 		let zero: Term = "zero"
 		let `nil` = Declaration("nil",
-			type: .Type => { A in Vector[A, zero] },
+			type: () => { A in Vector[A, zero] },
 			value: () => { A, B in B => id })
 
 		return Module("Vector", [ natural ], [ vector, cons, `nil` ])

--- a/Manifold/Module.swift
+++ b/Manifold/Module.swift
@@ -33,8 +33,8 @@ public struct Module {
 		let context = self.context
 		return definitions.flatMap { symbol, type, value -> [String] in
 			do {
-				try type.elaborateType(.Type, environment, context)
-				try value.elaborateType(type, environment, context)
+				let typeʹ = try type.elaborateType(.Type, environment, context)
+				try value.elaborateType(Term(term: typeʹ), environment, context)
 				return []
 			} catch {
 				return [ "\(self.name).\(symbol): \(error)" ]

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -36,9 +36,9 @@ extension Term {
 				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type2 ])
 				return .Unroll(.Lambda(j, type2, bodyType), .Lambda(i, t, b))
 
-			case let (.Lambda(i, .Some(type), body), .Some(.Type(n))):
-				let typeʹ = try type.elaborateType(.Type, environment, context)
-				return .Unroll(.Type(n), .Lambda(i, typeʹ, try body.elaborateType(.Type, environment, context + [ Name.Local(i) : type ])))
+			case let (.Lambda(i, type, body), .Some(.Type(n))):
+				let typeʹ = try type?.elaborateType(.Type, environment, context) ?? .Unroll(.Type(n + 1), .Type(n))
+				return .Unroll(.Lambda(i, .Type, .Type), .Lambda(i, typeʹ, try body.elaborateType(.Type, environment, context + [ Name.Local(i) : type ?? .Type(n) ])))
 
 			case let (_, .Some(b)):
 				let a = try elaborateType(nil, environment, context)

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -41,9 +41,9 @@ extension Term {
 				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type ])
 				return .Unroll(.Lambda(j, type, bodyType), .Lambda(i, t, b))
 
-			case let (.Lambda(i, .Some(type), body), .Some(.Type)):
-				try type.elaborateType(.Type, environment, context)
-				return try body.elaborateType(.Type, environment, context + [ Name.Local(i) : type ])
+			case let (.Lambda(i, .Some(type), body), .Some(.Type(n))):
+				let typeʹ = try type.elaborateType(.Type, environment, context)
+				return .Unroll(.Type(n), .Lambda(i, typeʹ, try body.elaborateType(.Type, environment, context + [ Name.Local(i) : type ])))
 
 			case let (_, .Some(b)):
 				let a = try elaborateType(nil, environment, context)

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -31,15 +31,10 @@ extension Term {
 			case let (.Type(m), .Some(.Type(n))) where n > m:
 				return try elaborateType(nil, environment, context)
 
-			case let (.Lambda(i, .Some(type), body), .Some(.Lambda(j, .Some(type2), bodyType))) where Term.equate(type, type2, environment):
-				let t = try type.elaborateType(.Type, environment, context)
-				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type ])
+			case let (.Lambda(i, type, body), .Some(.Lambda(j, .Some(type2), bodyType))) where type.map { Term.equate($0, type2, environment) } ?? true:
+				let t = try (type ?? type2).elaborateType(.Type, environment, context)
+				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type2 ])
 				return .Unroll(.Lambda(j, type2, bodyType), .Lambda(i, t, b))
-
-			case let (.Lambda(i, .None, body), .Some(.Lambda(j, .Some(type), bodyType))):
-				let t = try type.elaborateType(.Type, environment, context)
-				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type ])
-				return .Unroll(.Lambda(j, type, bodyType), .Lambda(i, t, b))
 
 			case let (.Lambda(i, .Some(type), body), .Some(.Type(n))):
 				let typeʹ = try type.elaborateType(.Type, environment, context)

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -32,7 +32,7 @@ extension Term {
 				return try elaborateType(nil, environment, context)
 
 			case let (.Lambda(i, type, body), .Some(.Lambda(j, .Some(type2), bodyType))) where type.map { Term.equate($0, type2, environment) } ?? true:
-				let t = try (type ?? type2).elaborateType(.Type, environment, context)
+				let t = try type2.elaborateType(.Type, environment, context)
 				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type2 ])
 				return .Unroll(.Lambda(j, type2, bodyType), .Lambda(i, t, b))
 

--- a/Manifold/TermContainerType+FreeVariables.swift
+++ b/Manifold/TermContainerType+FreeVariables.swift
@@ -35,4 +35,13 @@ extension TermContainerType {
 }
 
 
+extension Term {
+	public func generalize() -> Term {
+		return freeVariables.sort().reduce(self) {
+			.Lambda($1, nil, $0)
+		}
+	}
+}
+
+
 import Prelude

--- a/Manifold/TermContainerType+FreeVariables.swift
+++ b/Manifold/TermContainerType+FreeVariables.swift
@@ -18,7 +18,7 @@ extension TermContainerType {
 		}
 	}
 
-	public var freeVariables: Set<Int> {
+	public var freeVariables: [Int] {
 		return cata {
 			switch $0 {
 			case .Type, .Variable(.Global):
@@ -26,9 +26,9 @@ extension TermContainerType {
 			case let .Variable(.Local(i)):
 				return [ i ]
 			case let .Application(a, b):
-				return a.union(b)
+				return (a + b)
 			case let .Lambda(i, a, b):
-				return b.subtract([ i ]).union(a ?? [])
+				return (a ?? []) + b.filter { $0 != i }
 			}
 		}
 	}

--- a/Manifold/TermContainerType+FreeVariables.swift
+++ b/Manifold/TermContainerType+FreeVariables.swift
@@ -26,7 +26,7 @@ extension TermContainerType {
 			case let .Variable(.Local(i)):
 				return [ i ]
 			case let .Application(a, b):
-				return (a + b)
+				return a + b
 			case let .Lambda(i, a, b):
 				return (a ?? []) + b.filter { $0 != i }
 			}

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -50,6 +50,11 @@ final class TermTests: XCTestCase {
 	func testLambdasBindVariablesDeeply() {
 		assert(Term.Lambda(2, .Type, .Lambda(1, 2, .Lambda(0, .Type, .Application(2, .Application(1, 0))))).freeVariables, ==, [])
 	}
+
+
+	func testGeneralizationMaintainsLeftToRightOrdering() {
+		assert(Term.Lambda(0, 2, .Lambda(-1, 1, 0)).generalize(), ==, .Lambda(2, nil, .Lambda(1, nil, .Lambda(0, 2, .Lambda(-1, 1, 0)))))
+	}
 }
 
 

--- a/ManifoldTests/TermTests.swift
+++ b/ManifoldTests/TermTests.swift
@@ -52,6 +52,11 @@ final class TermTests: XCTestCase {
 	}
 
 
+	func testFreeVariablesAreOrderedByOccurence() {
+		assert(Array(Term.Application(.Application(.Application(1, 2), .Application(3, 4)), .Application(.Application(5, 6), .Application(7, 8))).freeVariables), ==, (1...8).map(id))
+	}
+
+
 	func testGeneralizationMaintainsLeftToRightOrdering() {
 		assert(Term.Lambda(0, 2, .Lambda(-1, 1, 0)).generalize(), ==, .Lambda(2, nil, .Lambda(1, nil, .Lambda(0, 2, .Lambda(-1, 1, 0)))))
 	}


### PR DESCRIPTION
- [x] Allows type annotations to be left off of function types when they will be typechecked against `Type`.
- ~~Allows type parameters to be omitted from argument lists and applications of values, inferring them from the type being checked against.~~ I don’t think I’m ready to add unification &c. to this.
- ~~Fixes #155.~~
