### PR TITLE
Definitional equality returns a term

### DIFF
--- a/Manifold/Term+DefinitionalEquality.swift
+++ b/Manifold/Term+DefinitionalEquality.swift
@@ -21,9 +21,6 @@ extension Term {
 		case (.Type, .Type):
 			return true
 
-		case let (.Variable(a), .Variable(b)):
-			return a == b
-
 		case let (.Application(a1, a2), .Application(b1, b2)):
 			return recur(a1, b1) && recur(a2, b2)
 

--- a/Manifold/Term+DefinitionalEquality.swift
+++ b/Manifold/Term+DefinitionalEquality.swift
@@ -2,8 +2,6 @@
 
 extension Term {
 	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term], var _ visited: Set<Name> = []) -> Bool {
-		if left == right { return true }
-
 		let recur: (Term, Term) -> Bool = {
 			equate($0, $1, environment, visited)
 		}
@@ -16,6 +14,8 @@ extension Term {
 		let (right, rnames) = normalize(right, visited)
 		visited.unionInPlace(lnames)
 		visited.unionInPlace(rnames)
+
+		if left == right { return right }
 
 		switch (left.out, right.out) {
 		case (.Type, .Type):

--- a/Manifold/Term+DefinitionalEquality.swift
+++ b/Manifold/Term+DefinitionalEquality.swift
@@ -1,8 +1,8 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Term {
-	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term], var _ visited: Set<Name> = []) -> Bool {
-		let recur: (Term, Term) -> Bool = {
+	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term], var _ visited: Set<Name> = []) -> Term? {
+		let recur: (Term, Term) -> Term? = {
 			equate($0, $1, environment, visited)
 		}
 
@@ -19,16 +19,22 @@ extension Term {
 
 		switch (left.out, right.out) {
 		case (.Type, .Type):
-			return true
+			return right
 
 		case let (.Application(a1, a2), .Application(b1, b2)):
-			return recur(a1, b1) && recur(a2, b2)
+			if let first = recur(a1, b1), second = recur(a2, b2) {
+				return .Application(first, second)
+			}
+			return nil
 
-		case let (.Lambda(_, .Some(a1), a2), .Lambda(_, .Some(b1), b2)):
-			return recur(a1, b1) && recur(a2, b2)
+		case let (.Lambda(_, .Some(a1), a2), .Lambda(i, .Some(b1), b2)):
+			if let type = recur(a1, b1), body = recur(a2, b2) {
+				return .Lambda(i, type, body)
+			}
+			return nil
 
 		default:
-			return false
+			return nil
 		}
 	}
 }

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -31,7 +31,7 @@ extension Term {
 			case let (.Type(m), .Some(.Type(n))) where n > m:
 				return try elaborateType(nil, environment, context)
 
-			case let (.Lambda(i, type, body), .Some(.Lambda(j, .Some(type2), bodyType))) where type.map { Term.equate($0, type2, environment) } ?? true:
+			case let (.Lambda(i, type, body), .Some(.Lambda(j, .Some(type2), bodyType))) where type.map { Term.equate($0, type2, environment) != nil } ?? true:
 				let t = try type2.elaborateType(.Type, environment, context)
 				let b = try body.elaborateType(bodyType.substitute(j, Term.Variable(Name.Local(i))), environment, context + [ Name.Local(i) : type2 ])
 				return .Unroll(.Lambda(j, type2, bodyType), .Lambda(i, t, b))
@@ -42,7 +42,7 @@ extension Term {
 
 			case let (_, .Some(b)):
 				let a = try elaborateType(nil, environment, context)
-				guard Term.equate(a.type, Term(b), environment) else {
+				guard let actual = Term.equate(a.type, Term(b), environment) else {
 					throw "Type mismatch: expected '\(self)' to be of type '\(Term(b))', but it was actually of type '\(a.type)' in context: \(Term.toString(context, separator: ":")), environment: \(Term.toString(environment, separator: "="))"
 				}
 				return a

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -42,7 +42,7 @@ extension Term {
 
 			case let (_, .Some(b)):
 				let a = try elaborateType(nil, environment, context)
-				guard let actual = Term.equate(a.type, Term(b), environment) else {
+				guard Term.equate(a.type, Term(b), environment) != nil else {
 					throw "Type mismatch: expected '\(self)' to be of type '\(Term(b))', but it was actually of type '\(a.type)' in context: \(Term.toString(context, separator: ":")), environment: \(Term.toString(environment, separator: "="))"
 				}
 				return a


### PR DESCRIPTION
This is intended to ease working with placeholders. For example, if we `equate(_, .Type, …)` we would expect to receive `.Type` back as the result.
