### PR TITLE
Embedded terms

### DIFF
--- a/Manifold.xcodeproj/project.pbxproj
+++ b/Manifold.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		D415A09B1B51EFDE001C15E5 /* Term+Construction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D415A09A1B51EFDE001C15E5 /* Term+Construction.swift */; };
 		D43AC8831BC1824D008762B7 /* Telescope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43AC8821BC1824D008762B7 /* Telescope.swift */; };
+		D43B6D1B1C1DB2CA008EF3D2 /* Module+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B6D1A1C1DB2CA008EF3D2 /* Module+String.swift */; };
 		D445417C1BCAB0C100F2946D /* Module+Unit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D445417B1BCAB0C100F2946D /* Module+Unit.swift */; };
 		D44541801BCAC38500F2946D /* Module+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = D445417F1BCAC38500F2946D /* Module+List.swift */; };
 		D44541841BCAEDCD00F2946D /* Term+WeakHeadNormalForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44541831BCAEDCD00F2946D /* Term+WeakHeadNormalForm.swift */; };
@@ -69,6 +70,7 @@
 /* Begin PBXFileReference section */
 		D415A09A1B51EFDE001C15E5 /* Term+Construction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Term+Construction.swift"; sourceTree = "<group>"; };
 		D43AC8821BC1824D008762B7 /* Telescope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Telescope.swift; sourceTree = "<group>"; };
+		D43B6D1A1C1DB2CA008EF3D2 /* Module+String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+String.swift"; sourceTree = "<group>"; };
 		D445417B1BCAB0C100F2946D /* Module+Unit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+Unit.swift"; sourceTree = "<group>"; };
 		D445417F1BCAC38500F2946D /* Module+List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Module+List.swift"; sourceTree = "<group>"; };
 		D44541831BCAEDCD00F2946D /* Term+WeakHeadNormalForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Term+WeakHeadNormalForm.swift"; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				D470CB971BDC27130003A931 /* Module+Vector.swift */,
 				D4ACE90C1BDC7E51009E928F /* Module+FiniteSet.swift */,
 				D4FB2D0A1BE44DAF00B3CCE0 /* Module+Functor.swift */,
+				D43B6D1A1C1DB2CA008EF3D2 /* Module+String.swift */,
 			);
 			name = Modules;
 			sourceTree = "<group>";
@@ -355,6 +358,7 @@
 			files = (
 				D445417C1BCAB0C100F2946D /* Module+Unit.swift in Sources */,
 				D4E9901C1BD3431D00F00CA7 /* Module+Either.swift in Sources */,
+				D43B6D1B1C1DB2CA008EF3D2 /* Module+String.swift in Sources */,
 				D415A09B1B51EFDE001C15E5 /* Term+Construction.swift in Sources */,
 				D44541901BCB028A00F2946D /* TermContainerType+CustomDebugStringConvertible.swift in Sources */,
 				D44541841BCAEDCD00F2946D /* Term+WeakHeadNormalForm.swift in Sources */,

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -38,6 +38,8 @@ public enum Expression<Recur> {
 			return equal(t1, u1) && equal(t2, u2)
 		case let (.Lambda(i, t, a), .Lambda(j, u, b)):
 			return i == j && ((t &&& u).map(equal) ?? (t == nil && u == nil)) && equal(a, b)
+		case let (.Embedded(a, t1), .Embedded(b, t2)) where a.dynamicType == b.dynamicType:
+			return equal(t1, t2)
 		default:
 			return false
 		}

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -5,7 +5,7 @@ public enum Expression<Recur> {
 	case Variable(Name)
 	case Application(Recur, Recur)
 	case Lambda(Int, Recur?, Recur)
-	case Embedded(Any, Recur)
+	case Embedded(Any, (Any, Any) -> Bool, Recur)
 
 
 	// MARK: Functor
@@ -20,8 +20,8 @@ public enum Expression<Recur> {
 			return try .Application(transform(a), transform(b))
 		case let .Lambda(i, a, b):
 			return try .Lambda(i, a.map(transform), transform(b))
-		case let .Embedded(a, b):
-			return try .Embedded(a, transform(b))
+		case let .Embedded(a, eq, b):
+			return try .Embedded(a, eq, transform(b))
 		}
 	}
 
@@ -38,8 +38,8 @@ public enum Expression<Recur> {
 			return equal(t1, u1) && equal(t2, u2)
 		case let (.Lambda(i, t, a), .Lambda(j, u, b)):
 			return i == j && ((t &&& u).map(equal) ?? (t == nil && u == nil)) && equal(a, b)
-		case let (.Embedded(a, t1), .Embedded(b, t2)) where a.dynamicType == b.dynamicType:
-			return equal(t1, t2)
+		case let (.Embedded(a, eq, t1), .Embedded(b, _, t2)) where a.dynamicType == b.dynamicType:
+			return eq(a, b) && equal(t1, t2)
 		default:
 			return false
 		}

--- a/Manifold/Expression.swift
+++ b/Manifold/Expression.swift
@@ -5,6 +5,7 @@ public enum Expression<Recur> {
 	case Variable(Name)
 	case Application(Recur, Recur)
 	case Lambda(Int, Recur?, Recur)
+	case Embedded(Any, Recur)
 
 
 	// MARK: Functor
@@ -19,6 +20,8 @@ public enum Expression<Recur> {
 			return try .Application(transform(a), transform(b))
 		case let .Lambda(i, a, b):
 			return try .Lambda(i, a.map(transform), transform(b))
+		case let .Embedded(a, b):
+			return try .Embedded(a, transform(b))
 		}
 	}
 

--- a/Manifold/Module+Directory.swift
+++ b/Manifold/Module+Directory.swift
@@ -13,5 +13,6 @@ extension Module {
 		sigma,
 		vector,
 		finiteSet,
+		string,
 	].map { ($0.name, $0) })
 }

--- a/Manifold/Module+Sigma.swift
+++ b/Manifold/Module+Sigma.swift
@@ -14,7 +14,7 @@ extension Module {
 
 		let second = Declaration("second",
 			type: () => { A in (A --> .Type) => { B in Sigma.ref[A, B] => { v in B[first.ref[A, B, v]] } } },
-			value: () => { A in () => { B in () => { v in v[(A => { x in B[x] })[first.ref[A, B, v]], () => { x in B[x] => id }] } } })
+			value: () => { A in () => { B in () => { v in v[B[first.ref[A, B, v]], () => { x in B[x] => id }] } } })
 
 		return Module("Sigma", [ Sigma, first, second ])
 	}

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -16,12 +16,8 @@ extension Module {
 
 		let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, Character.ref) }
 		func toTerm(characters: Swift.String.CharacterView) -> Term {
-			switch characters.first {
-			case let .Some(c):
-				return cons[Character.ref, embedCharacter(c), toTerm(characters.dropFirst())]
-			default:
-				return `nil`[Character.ref]
-			}
+			guard let c = characters.first else { return `nil`[Character.ref] }
+			return cons[Character.ref, embedCharacter(c), toTerm(characters.dropFirst())]
 		}
 
 		let toList = Declaration("toList",

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -2,6 +2,10 @@
 
 extension Module {
 	public static var string: Module {
-		return Module("String", [])
+		let String = Declaration("String",
+			type: .Type,
+			value: .Embedded(Swift.String.self))
+
+		return Module("String", [ String ])
 	}
 }

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -27,13 +27,19 @@ extension Module {
 			})
 
 		let embedString: Swift.String -> Term = { .Embedded($0, String.ref) }
+		let combine = Declaration("combine",
+			type: Character.ref --> String.ref --> String.ref,
+			value: Term.Embedded("combine1", Character.ref --> String.ref --> String.ref) { (c: Swift.Character) in
+				Term.Embedded("combine2", String.ref --> String.ref) { (s: Swift.String) in
+					Term.Embedded(Swift.String(c) + s, String.ref)
+				}
+			})
+
 		let fromList: Term = "fromList"
 		let _fromList = Declaration("fromList",
 			type: List[Character.ref] --> String.ref,
-			value: Term.Embedded("fromList", List[Character.ref] --> String.ref) {
-				$0[String.ref, () => { c, rest in fromList[rest] }, embedString("")]
-			})
+			value: () => { list in list[String.ref, () => { c, rest in combine.ref[c, fromList[rest]] }, embedString("")] })
 
-		return Module("String", [ list ], [ String, Character, toList, _fromList ])
+		return Module("String", [ list ], [ String, Character, toList, combine, _fromList ])
 	}
 }

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -26,6 +26,14 @@ extension Module {
 				toTerm(string.characters)
 			})
 
-		return Module("String", [ list ], [ String, Character, toList ])
+		let embedString: Swift.String -> Term = { .Embedded($0, String.ref) }
+		let fromList: Term = "fromList"
+		let _fromList = Declaration("fromList",
+			type: List[Character.ref] --> String.ref,
+			value: Term.Embedded("fromList", List[Character.ref] --> String.ref) {
+				$0[String.ref, () => { c, rest in fromList[rest] }, embedString("")]
+			})
+
+		return Module("String", [ list ], [ String, Character, toList, _fromList ])
 	}
 }

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -14,7 +14,7 @@ extension Module {
 			type: .Type,
 			value: .Embedded(Swift.Character.self))
 
-		let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, Character.ref) }
+		let embedCharacter: Swift.Character -> Term = { .Embedded($0, Character.ref) }
 		func toTerm(characters: Swift.String.CharacterView) -> Term {
 			guard let c = characters.first else { return `nil`[Character.ref] }
 			return cons[Character.ref, embedCharacter(c), toTerm(characters.dropFirst())]

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -15,5 +15,13 @@ extension Module {
 			value: .Embedded(Swift.Character.self))
 
 		return Module("String", [ String, Character ])
+		func toTerm(characters: Swift.String.CharacterView) -> Term {
+			switch characters.first {
+			case let .Some(c):
+				return cons[Character.ref, .Embedded(c), toTerm(characters.dropFirst())]
+			default:
+				return `nil`[Character.ref]
+			}
+		}
 	}
 }

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -1,0 +1,7 @@
+//  Copyright © 2015 Rob Rix. All rights reserved.
+
+extension Module {
+	public static var string: Module {
+		return Module("String", [])
+	}
+}

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -2,6 +2,10 @@
 
 extension Module {
 	public static var string: Module {
+		let List: Term = "List"
+		let cons: Term = "cons"
+		let `nil`: Term = "nil"
+
 		let String = Declaration("String",
 			type: .Type,
 			value: .Embedded(Swift.String.self))

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -22,9 +22,8 @@ extension Module {
 
 		let toList = Declaration("toList",
 			type: String.ref --> List[Character.ref],
-			value: () => { (string: Term) -> Term in
-				guard case let .Embedded(value as Swift.String, _, _) = string.out else { return ("toList" as Term)[string] }
-				return toTerm(value.characters)
+			value: Term.Embedded("toList", String.ref --> List[Character.ref]) { (string: Swift.String) -> Term in
+				toTerm(string.characters)
 			})
 
 		return Module("String", [ list ], [ String, Character, toList ])

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -6,6 +6,10 @@ extension Module {
 			type: .Type,
 			value: .Embedded(Swift.String.self))
 
-		return Module("String", [ String ])
+		let Character = Declaration("Character",
+			type: .Type,
+			value: .Embedded(Swift.Character.self))
+
+		return Module("String", [ String, Character ])
 	}
 }

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -14,7 +14,6 @@ extension Module {
 			type: .Type,
 			value: .Embedded(Swift.Character.self))
 
-		return Module("String", [ String, Character ])
 		func toTerm(characters: Swift.String.CharacterView) -> Term {
 			switch characters.first {
 			case let .Some(c):
@@ -23,5 +22,14 @@ extension Module {
 				return `nil`[Character.ref]
 			}
 		}
+
+		let toList = Declaration("toList",
+			type: String.ref --> List[Character.ref],
+			value: () => { (string: Term) -> Term in
+				guard case let .Embedded(value as Swift.String, _) = string.out else { return ("toList" as Term)[string] }
+				return toTerm(value.characters)
+			})
+
+		return Module("String", [ list ], [ String, Character, toList ])
 	}
 }

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -26,7 +26,7 @@ extension Module {
 		let toList = Declaration("toList",
 			type: String.ref --> List[Character.ref],
 			value: () => { (string: Term) -> Term in
-				guard case let .Embedded(value as Swift.String, _) = string.out else { return ("toList" as Term)[string] }
+				guard case let .Embedded(value as Swift.String, _, _) = string.out else { return ("toList" as Term)[string] }
 				return toTerm(value.characters)
 			})
 

--- a/Manifold/Module+String.swift
+++ b/Manifold/Module+String.swift
@@ -14,10 +14,11 @@ extension Module {
 			type: .Type,
 			value: .Embedded(Swift.Character.self))
 
+		let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, Character.ref) }
 		func toTerm(characters: Swift.String.CharacterView) -> Term {
 			switch characters.first {
 			case let .Some(c):
-				return cons[Character.ref, .Embedded(c), toTerm(characters.dropFirst())]
+				return cons[Character.ref, embedCharacter(c), toTerm(characters.dropFirst())]
 			default:
 				return `nil`[Character.ref]
 			}

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -21,6 +21,14 @@ extension Term {
 		return Term(.Lambda(i, type, body))
 	}
 
+	public static func Embedded(name: String, _ type: Term, _ evaluator: Term throws -> Term) -> Term {
+		let equal: (Any, Any) -> Bool = { a, b in
+			guard let a = a as? (String, Term throws -> Term), b = b as? (String, Term throws -> Term) else { return false }
+			return a.0 == b.0
+		}
+		return Term(.Embedded((name, evaluator), equal, type))
+	}
+
 	public static func Embedded<A>(value: A, _ equal: (A, A) -> Bool, _ type: Term) -> Term {
 		let equal: (Any, Any) -> Bool = { a, b in
 			guard let a = a as? A, b = b as? A else { return false }

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -25,6 +25,10 @@ extension Term {
 		return Term(.Embedded(value, type))
 	}
 
+	public static func Embedded<A>(value: A) -> Term {
+		return Term(.Embedded(value, .Embedded(A.self, .Type)))
+	}
+
 
 	public subscript (operands: Term...) -> Term {
 		return operands.reduce(self, combine: Term.Application)

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -26,7 +26,7 @@ extension Term {
 	}
 
 	public static func Embedded<A>(value: A) -> Term {
-		return Term(.Embedded(value, .Embedded(A.self, .Type)))
+		return Term(.Embedded(value, .Embedded(A.self)))
 	}
 
 	public static func Embedded<A>(type: A.Type) -> Term {

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -26,11 +26,11 @@ extension Term {
 	}
 
 	public static func Embedded<A>(value: A) -> Term {
-		return Term(.Embedded(value, .Embedded(A.self)))
+		return .Embedded(value, .Embedded(A.self))
 	}
 
 	public static func Embedded<A>(type: A.Type) -> Term {
-		return Term(.Embedded(A.self, .Type))
+		return .Embedded(A.self, .Type)
 	}
 
 

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -29,6 +29,13 @@ extension Term {
 		return Term(.Embedded((name, evaluator), equal, type))
 	}
 
+	public static func Embedded<A>(name: String, _ type: Term, _ evaluator: A throws -> Term) -> Term {
+		return Embedded(name, type) { term in
+			guard case let .Embedded(value as A, _, _) = term.out else { throw "illegal application of '\(name)' to \(term)" }
+			return try evaluator(value)
+		}
+	}
+
 	public static func Embedded<A>(value: A, _ equal: (A, A) -> Bool, _ type: Term) -> Term {
 		let equal: (Any, Any) -> Bool = { a, b in
 			guard let a = a as? A, b = b as? A else { return false }

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -21,6 +21,10 @@ extension Term {
 		return Term(.Lambda(i, type, body))
 	}
 
+	public static func Embedded(value: Any, _ type: Term) -> Term {
+		return Term(.Embedded(value, type))
+	}
+
 
 	public subscript (operands: Term...) -> Term {
 		return operands.reduce(self, combine: Term.Application)

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -29,6 +29,10 @@ extension Term {
 		return Term(.Embedded(value, .Embedded(A.self, .Type)))
 	}
 
+	public static func Embedded<A>(type: A.Type) -> Term {
+		return Term(.Embedded(A.self, .Type))
+	}
+
 
 	public subscript (operands: Term...) -> Term {
 		return operands.reduce(self, combine: Term.Application)

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -31,7 +31,7 @@ extension Term {
 
 	public static func Embedded<A>(name: String, _ type: Term, _ evaluator: A throws -> Term) -> Term {
 		return Embedded(name, type) { term in
-			guard case let .Embedded(value as A, _, _) = term.out else { throw "illegal application of '\(name)' to \(term)" }
+			guard case let .Embedded(value as A, _, _) = term.out else { throw "Illegal application of '\(name)' to '\(term)'" }
 			return try evaluator(value)
 		}
 	}

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -21,16 +21,20 @@ extension Term {
 		return Term(.Lambda(i, type, body))
 	}
 
-	public static func Embedded<A>(value: A, _ type: Term) -> Term {
+	public static func Embedded<A>(value: A, _ equal: (A, A) -> Bool, _ type: Term) -> Term {
 		return Term(.Embedded(value as Any, type))
 	}
 
-	public static func Embedded<A>(value: A) -> Term {
+	public static func Embedded<A: Equatable>(value: A, _ type: Term) -> Term {
+		return .Embedded(value, ==, type)
+	}
+
+	public static func Embedded<A: Equatable>(value: A) -> Term {
 		return .Embedded(value, .Embedded(A.self))
 	}
 
-	public static func Embedded<A>(type: A.Type) -> Term {
-		return .Embedded(A.self, .Type)
+	public static func Embedded<A: Equatable>(type: A.Type) -> Term {
+		return .Embedded(A.self, ==, .Type)
 	}
 
 

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -22,7 +22,11 @@ extension Term {
 	}
 
 	public static func Embedded<A>(value: A, _ equal: (A, A) -> Bool, _ type: Term) -> Term {
-		return Term(.Embedded(value as Any, type))
+		let equal: (Any, Any) -> Bool = { a, b in
+			guard let a = a as? A, b = b as? A else { return false }
+			return equal(a, b)
+		}
+		return Term(.Embedded(value as Any, equal, type))
 	}
 
 	public static func Embedded<A: Equatable>(value: A, _ type: Term) -> Term {

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -21,8 +21,8 @@ extension Term {
 		return Term(.Lambda(i, type, body))
 	}
 
-	public static func Embedded(value: Any, _ type: Term) -> Term {
-		return Term(.Embedded(value, type))
+	public static func Embedded<A>(value: A, _ type: Term) -> Term {
+		return Term(.Embedded(value as Any, type))
 	}
 
 	public static func Embedded<A>(value: A) -> Term {

--- a/Manifold/Term+Construction.swift
+++ b/Manifold/Term+Construction.swift
@@ -46,7 +46,7 @@ extension Term {
 	}
 
 	public static func Embedded<A: Equatable>(type: A.Type) -> Term {
-		return .Embedded(A.self, ==, .Type)
+		return .Embedded(A.self, (==) as (A.Type, A.Type) -> Bool, .Type)
 	}
 
 

--- a/Manifold/Term+DefinitionalEquality.swift
+++ b/Manifold/Term+DefinitionalEquality.swift
@@ -2,23 +2,16 @@
 
 extension Term {
 	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term]) -> Term? {
-		var visited: Set<Name> = []
-		return equate(left, right, environment, &visited)
-	}
-
-	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term], inout _ visited: Set<Name>) -> Term? {
 		let recur: (Term, Term) -> Term? = {
-			equate($0, $1, environment, &visited)
+			equate($0, $1, environment)
 		}
 
-		let normalize: (Term, Set<Name>) -> (Term, Set<Name>) = { (term, var visited) in
-			(term.weakHeadNormalForm(environment, shouldRecur: false, visited: &visited), visited)
+		let normalize: Term -> Term = { term in
+			term.weakHeadNormalForm(environment, shouldRecur: false)
 		}
 
-		let (left, lnames) = normalize(left, visited)
-		let (right, rnames) = normalize(right, visited)
-		visited.unionInPlace(lnames)
-		visited.unionInPlace(rnames)
+		let left = normalize(left)
+		let right = normalize(right)
 
 		if left == right { return right }
 

--- a/Manifold/Term+DefinitionalEquality.swift
+++ b/Manifold/Term+DefinitionalEquality.swift
@@ -1,9 +1,14 @@
 //  Copyright © 2015 Rob Rix. All rights reserved.
 
 extension Term {
-	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term], var _ visited: Set<Name> = []) -> Term? {
+	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term]) -> Term? {
+		var visited: Set<Name> = []
+		return equate(left, right, environment, &visited)
+	}
+
+	public static func equate(left: Term, _ right: Term, _ environment: [Name:Term], inout _ visited: Set<Name>) -> Term? {
 		let recur: (Term, Term) -> Term? = {
-			equate($0, $1, environment, visited)
+			equate($0, $1, environment, &visited)
 		}
 
 		let normalize: (Term, Set<Name>) -> (Term, Set<Name>) = { (term, var visited) in

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -28,6 +28,10 @@ extension Term {
 				let bʹ = try b.elaborateType(nil, environment, context + [ .Local(i): a ])
 				return .Unroll(a => { bʹ.annotation.substitute(i, $0) }, .Lambda(i, aʹ, bʹ))
 
+			case let (.Embedded(value, type), .None):
+				let typeʹ = try type.elaborateType(.Type, environment, context)
+				return .Unroll(type, .Embedded(value, typeʹ))
+
 			case let (.Type(m), .Some(.Type(n))) where n > m:
 				return try elaborateType(nil, environment, context)
 

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -28,9 +28,9 @@ extension Term {
 				let bʹ = try b.elaborateType(nil, environment, context + [ .Local(i): a ])
 				return .Unroll(a => { bʹ.annotation.substitute(i, $0) }, .Lambda(i, aʹ, bʹ))
 
-			case let (.Embedded(value, type), .None):
+			case let (.Embedded(value, eq, type), .None):
 				let typeʹ = try type.elaborateType(.Type, environment, context)
-				return .Unroll(type, .Embedded(value, typeʹ))
+				return .Unroll(type, .Embedded(value, eq, typeʹ))
 
 			case let (.Type(m), .Some(.Type(n))) where n > m:
 				return try elaborateType(nil, environment, context)

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -18,7 +18,7 @@ extension Term {
 			case let (.Application(a, b), .None):
 				let aʹ = try a.elaborateType(nil, environment, context)
 				guard case let .Lambda(i, type, body) = aʹ.annotation.weakHeadNormalForm(environment).out else {
-					throw "Illegal application of \(self) : \(aʹ.annotation) in context: \(Term.toString(context, separator: ":")), environment: \(Term.toString(environment, separator: "="))"
+					throw "Illegal application of \(a) : \(aʹ.annotation) in context: \(Term.toString(context, separator: ":")), environment: \(Term.toString(environment, separator: "="))"
 				}
 				let bʹ = try b.elaborateType(type, environment, context)
 				return .Unroll(body.substitute(i, b), .Application(aʹ, bʹ))

--- a/Manifold/Term+Elaboration.swift
+++ b/Manifold/Term+Elaboration.swift
@@ -16,12 +16,12 @@ extension Term {
 				return .Unroll(type, .Variable(name))
 
 			case let (.Application(a, b), .None):
-				let a = try a.elaborateType(nil, environment, context)
-				guard case let .Lambda(i, type, body) = a.annotation.weakHeadNormalForm(environment).out else {
-					throw "Illegal application of \(self) : \(a.annotation) in context: \(Term.toString(context, separator: ":")), environment: \(Term.toString(environment, separator: "="))"
+				let aʹ = try a.elaborateType(nil, environment, context)
+				guard case let .Lambda(i, type, body) = aʹ.annotation.weakHeadNormalForm(environment).out else {
+					throw "Illegal application of \(self) : \(aʹ.annotation) in context: \(Term.toString(context, separator: ":")), environment: \(Term.toString(environment, separator: "="))"
 				}
 				let bʹ = try b.elaborateType(type, environment, context)
-				return .Unroll(body.substitute(i, b), .Application(a, bʹ))
+				return .Unroll(body.substitute(i, b), .Application(aʹ, bʹ))
 
 			case let (.Lambda(i, .Some(a), b), .None):
 				let aʹ = try a.elaborateType(.Type, environment, context)

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -13,7 +13,7 @@ extension Term {
 			case let .Lambda(i, _, body):
 				return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
 
-			case let .Embedded(evaluator as Term throws -> Term, _, _):
+			case let .Embedded((_, evaluator) as (String, Term throws -> Term), _, _):
 				return try evaluator(b.evaluate(environment)).evaluate(environment)
 
 			default:

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -4,17 +4,13 @@ extension Term {
 	public func evaluate(environment: [Name:Term] = [:]) throws -> Term {
 		switch out {
 		case let .Variable(i):
-			if let found = environment[i] {
-				return found
-			}
-			throw "Illegal free variable \(i)"
+			guard let found = environment[i] else { throw "Illegal free variable \(i)" }
+			return found
 
 		case let .Application(a, b):
 			let a = try a.evaluate(environment)
-			if case let .Lambda(i, _, body) = a.out {
-				return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
-			}
-			throw "Illegal application of non-lambda term \(a) to \(b)"
+			guard case let .Lambda(i, _, body) = a.out else { throw "Illegal application of non-lambda term \(a) to \(b)" }
+			return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
 
 		default:
 			return self

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -9,8 +9,12 @@ extension Term {
 
 		case let .Application(a, b):
 			let aʹ = try a.evaluate(environment)
-			guard case let .Lambda(i, _, body) = aʹ.out else { throw "Illegal application of non-lambda term \(a)↓\(aʹ) to \(b)" }
-			return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
+			switch aʹ.out {
+			case let .Lambda(i, _, body):
+				return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
+			default:
+				throw "Illegal application of non-lambda term \(a)↓\(aʹ) to \(b)"
+			}
 
 		default:
 			return self

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -8,8 +8,8 @@ extension Term {
 			return found
 
 		case let .Application(a, b):
-			let a = try a.evaluate(environment)
-			guard case let .Lambda(i, _, body) = a.out else { throw "Illegal application of non-lambda term \(a) to \(b)" }
+			let aʹ = try a.evaluate(environment)
+			guard case let .Lambda(i, _, body) = aʹ.out else { throw "Illegal application of non-lambda term \(a)↓\(aʹ) to \(b)" }
 			return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
 
 		default:

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -12,6 +12,10 @@ extension Term {
 			switch aʹ.out {
 			case let .Lambda(i, _, body):
 				return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
+
+			case let .Embedded(evaluator as Term throws -> Term, _, _):
+				return try evaluator(b.evaluate(environment)).evaluate(environment)
+
 			default:
 				throw "Illegal application of non-lambda term \(a)↓\(aʹ) to \(b)"
 			}

--- a/Manifold/Term+Evaluation.swift
+++ b/Manifold/Term+Evaluation.swift
@@ -8,12 +8,14 @@ extension Term {
 				return found
 			}
 			throw "Illegal free variable \(i)"
+
 		case let .Application(a, b):
 			let a = try a.evaluate(environment)
 			if case let .Lambda(i, _, body) = a.out {
 				return try body.substitute(i, b.evaluate(environment)).evaluate(environment)
 			}
 			throw "Illegal application of non-lambda term \(a) to \(b)"
+
 		default:
 			return self
 		}

--- a/Manifold/Term+Substitution.swift
+++ b/Manifold/Term+Substitution.swift
@@ -2,13 +2,19 @@
 
 extension Term {
 	public func substitute(i: Int, _ expression: Term) -> Term {
-		return cata { (t: Expression<Term>) in
-			switch t {
-			case let .Variable(.Local(j)) where i == j:
-				return expression
-			default:
-				return Term(t)
-			}
+		switch out {
+		case let .Variable(.Local(j)) where i == j:
+			return expression
+		case let .Lambda(j, type, body):
+			return .Lambda(j, type?.substitute(i, expression), i == j
+				? body
+				: body.substitute(i, expression))
+		case let .Application(a, b):
+			return .Application(a.substitute(i, expression), b.substitute(i, expression))
+		case let .Embedded(a, eq, type):
+			return .Embedded(a, eq, type.substitute(i, expression))
+		default:
+			return self
 		}
 	}
 }

--- a/Manifold/Term+WeakHeadNormalForm.swift
+++ b/Manifold/Term+WeakHeadNormalForm.swift
@@ -2,24 +2,17 @@
 
 extension Term {
 	public func weakHeadNormalForm(environment: [Name:Term], shouldRecur: Bool = true) -> Term {
-		var visited: Set<Name> = []
-		return weakHeadNormalForm(environment, shouldRecur: shouldRecur, visited: &visited)
-	}
-
-	func weakHeadNormalForm(environment: [Name:Term], shouldRecur: Bool = true, inout visited: Set<Name>) -> Term {
 		let unfold: Term -> Term = {
-			$0.weakHeadNormalForm(environment, shouldRecur: shouldRecur, visited: &visited)
+			$0.weakHeadNormalForm(environment, shouldRecur: shouldRecur)
 		}
 		let done: Term -> Term = {
-			$0.weakHeadNormalForm(environment, shouldRecur: false, visited: &visited)
+			$0.weakHeadNormalForm(environment, shouldRecur: false)
 		}
 		switch out {
-		case let .Variable(name) where shouldRecur && !visited.contains(name):
-			visited.insert(name)
+		case let .Variable(name) where shouldRecur:
 			return environment[name].map(done) ?? self
 
-		case let .Variable(name) where !visited.contains(name):
-			visited.insert(name)
+		case let .Variable(name):
 			return environment[name] ?? self
 
 		case let .Application(t1, t2):
@@ -29,7 +22,6 @@ extension Term {
 				return unfold(body.substitute(i, t2))
 
 			case let .Variable(name) where shouldRecur:
-				visited.insert(name)
 				let t2 = unfold(t2)
 				return environment[name].map { .Application($0, t2) }.map(done) ?? .Application(t1, t2)
 

--- a/Manifold/TermContainerType+CustomDebugStringConvertible.swift
+++ b/Manifold/TermContainerType+CustomDebugStringConvertible.swift
@@ -12,6 +12,8 @@ extension TermContainerType {
 				return ".Application(\(a), \(b))"
 			case let .Lambda(i, a, b):
 				return ".Lambda(\(i), \(a), \(b))"
+			case let .Embedded(value, type):
+				return ".Embedded(\(String(reflecting: value)), \(type))"
 			}
 		}
 	}

--- a/Manifold/TermContainerType+CustomDebugStringConvertible.swift
+++ b/Manifold/TermContainerType+CustomDebugStringConvertible.swift
@@ -12,8 +12,8 @@ extension TermContainerType {
 				return ".Application(\(a), \(b))"
 			case let .Lambda(i, a, b):
 				return ".Lambda(\(i), \(a), \(b))"
-			case let .Embedded(value, type):
-				return ".Embedded(\(String(reflecting: value)), \(type))"
+			case let .Embedded(value, eq, type):
+				return ".Embedded(\(String(reflecting: value)), \(String(reflecting: eq)), \(type))"
 			}
 		}
 	}

--- a/Manifold/TermContainerType+CustomStringConvertible.swift
+++ b/Manifold/TermContainerType+CustomStringConvertible.swift
@@ -27,6 +27,9 @@ extension TermContainerType {
 
 			case let .Lambda(variable, _, (_, (body, _))):
 				return ("λ \(Name.Local(variable)) . \(body)", true)
+
+			case let .Embedded(value, (_, (type, _))):
+				return ("\(value) : \(type)", true)
 			}
 		}
 		return out

--- a/Manifold/TermContainerType+CustomStringConvertible.swift
+++ b/Manifold/TermContainerType+CustomStringConvertible.swift
@@ -28,7 +28,7 @@ extension TermContainerType {
 			case let .Lambda(variable, _, (_, (body, _))):
 				return ("λ \(Name.Local(variable)) . \(body)", true)
 
-			case let .Embedded(value, (_, (type, _))):
+			case let .Embedded(value, _, (_, (type, _))):
 				return ("'\(value)' : \(type)", true)
 			}
 		}

--- a/Manifold/TermContainerType+CustomStringConvertible.swift
+++ b/Manifold/TermContainerType+CustomStringConvertible.swift
@@ -29,7 +29,7 @@ extension TermContainerType {
 				return ("λ \(Name.Local(variable)) . \(body)", true)
 
 			case let .Embedded(value, (_, (type, _))):
-				return ("\(value) : \(type)", true)
+				return ("'\(value)' : \(type)", true)
 			}
 		}
 		return out

--- a/Manifold/TermContainerType+FreeVariables.swift
+++ b/Manifold/TermContainerType+FreeVariables.swift
@@ -14,7 +14,7 @@ extension TermContainerType {
 				return i < 0 ? max(a, b) : max(i, a)
 			case let .Lambda(i, .None, b):
 				return i < 0 ? b : i
-			case let .Embedded(_, type):
+			case let .Embedded(_, _, type):
 				return type
 			}
 		}
@@ -31,7 +31,7 @@ extension TermContainerType {
 				return a + b
 			case let .Lambda(i, a, b):
 				return (a ?? []) + b.filter { $0 != i }
-			case let .Embedded(_, type):
+			case let .Embedded(_, _, type):
 				return type
 			}
 		}

--- a/Manifold/TermContainerType+FreeVariables.swift
+++ b/Manifold/TermContainerType+FreeVariables.swift
@@ -14,6 +14,8 @@ extension TermContainerType {
 				return i < 0 ? max(a, b) : max(i, a)
 			case let .Lambda(i, .None, b):
 				return i < 0 ? b : i
+			case let .Embedded(_, type):
+				return type
 			}
 		}
 	}
@@ -29,6 +31,8 @@ extension TermContainerType {
 				return a + b
 			case let .Lambda(i, a, b):
 				return (a ?? []) + b.filter { $0 != i }
+			case let .Embedded(_, type):
+				return type
 			}
 		}
 	}

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -166,7 +166,7 @@ private let encodedList: Module = {
 	return Module("EncodedList", [ list, cons, `nil` ])
 }()
 
-private let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, "Character") }
+private let embedCharacter: Character -> Term = { Term.Embedded($0, "Character") }
 
 
 import Assertions

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -166,7 +166,7 @@ private let encodedList: Module = {
 	return Module("EncodedList", [ list, cons, `nil` ])
 }()
 
-private let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, Character) }
+private let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, "Character") }
 
 
 import Assertions

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -67,6 +67,21 @@ final class ModuleTests: XCTestCase {
 			assert(Module.list.environment[symbol], ==, value, message: "'\(symbol)' expected '\(value)', actual '\(Module.list.environment[symbol])'")
 		}
 	}
+
+
+	// MARK: String
+
+	func testStringToListConversion() {
+		let environment = Module.string.environment
+		let toList: Term = "toList"
+		let String: Term = "String"
+		let string = Term.Embedded("hi", String)
+		let Character: Term = "Character"
+		let cons: Term = "cons"
+		let `nil`: Term = "nil"
+		let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, Character) }
+		assert(try? toList[string].evaluate(environment), ==, try? cons[Character, embedCharacter("h"), cons[Character, embedCharacter("i"), `nil`[Character]]].evaluate(environment))
+	}
 }
 
 

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -104,10 +104,13 @@ final class ModuleTests: XCTestCase {
 	func testListToStringConversion() {
 		let environment = Module.string.environment
 		let Character: Term = "Character"
+		let cons: Term = "cons"
 		let `nil`: Term = "nil"
 		let fromList: Term = "fromList"
 		let nilTerm: Term = fromList[`nil`[Character]]
+		let consTerm: Term = fromList[cons[Character, embedCharacter("a"), `nil`[Character]]]
 		assert(try? nilTerm.evaluate(environment), ==, Term.Embedded("", "String"))
+		assert(try? consTerm.evaluate(environment), ==, Term.Embedded("a", "String"))
 	}
 }
 

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -68,6 +68,26 @@ final class ModuleTests: XCTestCase {
 		}
 	}
 
+	func testListValuesAsEliminators() {
+		let module = Module("test", [ Module.list, Module.unit, Module.boolean ], [])
+		let List: Term = "List"
+		let cons: Term = "cons"
+		let `nil`: Term = "nil"
+		let Unit: Term = "Unit"
+		let unit: Term = "unit"
+		let Boolean: Term = "Boolean"
+		let `true`: Term = "true"
+		let `false`: Term = "false"
+		let list: Term = cons[Unit, unit, `nil`[Unit]]
+
+		let isEmpty = List[Unit] => { list in
+			list[Boolean, (unit, List[Unit]) => { _ in `false` }, `true`]
+		}
+
+		assert((try? isEmpty[list].evaluate(module.environment)).flatMap { Term.equate($0, `false`, module.environment) }, !=, nil)
+		assert((try? isEmpty[`nil`[Unit]].evaluate(module.environment)).flatMap { Term.equate($0, `true`, module.environment) }, !=, nil)
+	}
+
 
 	// MARK: String
 

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -80,6 +80,15 @@ final class ModuleTests: XCTestCase {
 		let `nil`: Term = "nil"
 		assert(try? toList[string].evaluate(environment), ==, try? cons[Character, embedCharacter("h"), cons[Character, embedCharacter("i"), `nil`[Character]]].evaluate(environment))
 	}
+
+	func testListToStringConversion() {
+		let environment = Module.string.environment
+		let Character: Term = "Character"
+		let `nil`: Term = "nil"
+		let fromList: Term = "fromList"
+		let nilTerm: Term = fromList[`nil`[Character]]
+		assert(try? nilTerm.evaluate(environment), ==, Term.Embedded("", "String"))
+	}
 }
 
 
@@ -169,6 +178,6 @@ private let embedCharacter: Character -> Term = { Term.Embedded($0, "Character")
 
 
 import Assertions
-import Manifold
+@testable import Manifold
 import Prelude
 import XCTest

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -74,8 +74,7 @@ final class ModuleTests: XCTestCase {
 	func testStringToListConversion() {
 		let environment = Module.string.environment
 		let toList: Term = "toList"
-		let String: Term = "String"
-		let string = Term.Embedded("hi", String)
+		let string = Term.Embedded("hi", "String")
 		let Character: Term = "Character"
 		let cons: Term = "cons"
 		let `nil`: Term = "nil"

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -109,8 +109,10 @@ final class ModuleTests: XCTestCase {
 		let fromList: Term = "fromList"
 		let nilTerm: Term = fromList[`nil`[Character]]
 		let consTerm: Term = fromList[cons[Character, embedCharacter("a"), `nil`[Character]]]
+		let term = fromList[cons[Character, embedCharacter("h"), cons[Character, embedCharacter("i"), `nil`[Character]]]]
 		assert(try? nilTerm.evaluate(environment), ==, Term.Embedded("", "String"))
 		assert(try? consTerm.evaluate(environment), ==, Term.Embedded("a", "String"))
+		assert(try? term.evaluate(environment), ==, Term.Embedded("hi", "String"))
 	}
 }
 

--- a/ManifoldTests/ModuleTests.swift
+++ b/ManifoldTests/ModuleTests.swift
@@ -79,7 +79,6 @@ final class ModuleTests: XCTestCase {
 		let Character: Term = "Character"
 		let cons: Term = "cons"
 		let `nil`: Term = "nil"
-		let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, Character) }
 		assert(try? toList[string].evaluate(environment), ==, try? cons[Character, embedCharacter("h"), cons[Character, embedCharacter("i"), `nil`[Character]]].evaluate(environment))
 	}
 }
@@ -166,6 +165,8 @@ private let encodedList: Module = {
 
 	return Module("EncodedList", [ list, cons, `nil` ])
 }()
+
+private let embedCharacter: Swift.Character -> Term = { Term.Embedded($0, Character) }
 
 
 import Assertions


### PR DESCRIPTION
- [x] Implements the embedding of Swift values into Manifold terms.
- [x] Adds a `String` module which embeds Swift’s strings into Manifold.
- [x] Embed functions producing terms?
- [x] Evaluate functions at runtime.
- [x] Test that the `String.toList` function behaves correctly.
- [x] Add a `String.fromList` function. 
- [x] Test that the `String.fromList` function behaves correctly.
- [x] Fixes #175.
